### PR TITLE
[PR] Supabase 로그인, 회원가입 연동

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "19.2.4",
         "react-hook-form": "^7.74.0",
         "react-icons": "^5.6.0",
+        "resend": "^6.12.2",
         "shadcn": "^4.4.0",
         "tailwind-merge": "^3.5.0",
         "three": "^0.184.0",
@@ -2033,6 +2034,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.0.tgz",
       "integrity": "sha512-90abYK2q5/qDM+GACs9zRvc5KhEEpEWqWlHSd64zTPNxg+9wCJvTfyD9x2so7hlQhjRYO1Fa6flR3BC/kpTFkA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2100,6 +2102,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.104.1",
@@ -2682,6 +2690,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
       "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -5388,6 +5397,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -8263,6 +8278,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -8728,6 +8749,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -9337,6 +9379,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stats-gl": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
@@ -9664,6 +9716,16 @@
         "react": ">=17.0"
       }
     },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -9711,7 +9773,8 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -10302,6 +10365,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.2.4",
     "react-hook-form": "^7.74.0",
     "react-icons": "^5.6.0",
+    "resend": "^6.12.2",
     "shadcn": "^4.4.0",
     "tailwind-merge": "^3.5.0",
     "three": "^0.184.0",

--- a/src/app/api/auth/send-otp/route.ts
+++ b/src/app/api/auth/send-otp/route.ts
@@ -5,7 +5,7 @@ import { Resend } from 'resend';
 const OTP_SECRET = process.env.OTP_SECRET!;
 
 function generateOtp(): string {
-  return Math.floor(10000000 + Math.random() * 90000000).toString();
+  return crypto.randomInt(0, 100000000).toString().padStart(8, '0');
 }
 
 function hashOtp(otp: string): string {

--- a/src/app/api/auth/send-otp/route.ts
+++ b/src/app/api/auth/send-otp/route.ts
@@ -9,16 +9,21 @@ function generateOtp(): string {
   return Math.floor(10000000 + Math.random() * 90000000).toString();
 }
 
+function hashOtp(otp: string): string {
+  return crypto.createHmac('sha256', OTP_SECRET).update(otp).digest('hex');
+}
+
 function createOtpToken(email: string, otp: string): string {
   const expiresAt = Date.now() + 10 * 60 * 1000;
-  const payload = `${email}:${otp}:${expiresAt}`;
+  const otpHash = hashOtp(otp);
+  const payload = `${email}:${otpHash}:${expiresAt}`;
   const sig = crypto
     .createHmac('sha256', OTP_SECRET)
     .update(payload)
     .digest('hex');
-  return Buffer.from(JSON.stringify({ email, otp, expiresAt, sig })).toString(
-    'base64'
-  );
+  return Buffer.from(
+    JSON.stringify({ email, otpHash, expiresAt, sig })
+  ).toString('base64');
 }
 
 export async function POST(req: NextRequest) {

--- a/src/app/api/auth/send-otp/route.ts
+++ b/src/app/api/auth/send-otp/route.ts
@@ -1,0 +1,70 @@
+import crypto from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const OTP_SECRET = process.env.OTP_SECRET!;
+
+function generateOtp(): string {
+  return Math.floor(10000000 + Math.random() * 90000000).toString();
+}
+
+function createOtpToken(email: string, otp: string): string {
+  const expiresAt = Date.now() + 10 * 60 * 1000;
+  const payload = `${email}:${otp}:${expiresAt}`;
+  const sig = crypto
+    .createHmac('sha256', OTP_SECRET)
+    .update(payload)
+    .digest('hex');
+  return Buffer.from(JSON.stringify({ email, otp, expiresAt, sig })).toString(
+    'base64'
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const { email } = await req.json();
+
+  if (!email) {
+    return NextResponse.json(
+      { error: '이메일을 입력해주세요.' },
+      { status: 400 }
+    );
+  }
+
+  const otp = generateOtp();
+  const token = createOtpToken(email, otp);
+
+  const { error } = await resend.emails.send({
+    from: process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev',
+    to: email,
+    subject: '[스타아트] 이메일 인증번호',
+    html: `
+      <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
+        <h2 style="color: #1a1a2e;">스타아트 이메일 인증</h2>
+        <p>아래 인증번호를 입력해주세요. <strong>10분</strong> 이내에 유효합니다.</p>
+        <div style="font-size: 32px; font-weight: bold; letter-spacing: 8px; color: #f5bc3e; padding: 24px; background: #faf7f2; border-radius: 12px; text-align: center;">
+          ${otp}
+        </div>
+        <p style="color: #999; font-size: 13px; margin-top: 16px;">본인이 요청하지 않은 경우 이 메일을 무시해주세요.</p>
+      </div>
+    `,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: '이메일 발송에 실패했습니다.' },
+      { status: 500 }
+    );
+  }
+
+  const response = NextResponse.json({ success: true });
+  response.cookies.set('otp_token', token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 10 * 60,
+    path: '/',
+    sameSite: 'lax',
+  });
+
+  return response;
+}

--- a/src/app/api/auth/send-otp/route.ts
+++ b/src/app/api/auth/send-otp/route.ts
@@ -2,7 +2,6 @@ import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
 const OTP_SECRET = process.env.OTP_SECRET!;
 
 function generateOtp(): string {
@@ -27,6 +26,7 @@ function createOtpToken(email: string, otp: string): string {
 }
 
 export async function POST(req: NextRequest) {
+  const resend = new Resend(process.env.RESEND_API_KEY);
   const { email } = await req.json();
 
   if (!email) {

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,88 @@
+import crypto from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const OTP_SECRET = process.env.OTP_SECRET!;
+
+interface OtpToken {
+  email: string;
+  otp: string;
+  expiresAt: number;
+  sig: string;
+}
+
+function verifyOtpToken(token: string, email: string, otp: string): boolean {
+  try {
+    const {
+      email: te,
+      otp: to,
+      expiresAt,
+      sig,
+    }: OtpToken = JSON.parse(Buffer.from(token, 'base64').toString());
+
+    if (te !== email || to !== otp) return false;
+    if (Date.now() > expiresAt) return false;
+
+    const payload = `${te}:${to}:${expiresAt}`;
+    const expected = crypto
+      .createHmac('sha256', OTP_SECRET)
+      .update(payload)
+      .digest('hex');
+    return crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const { email, otp, password, name, role, organization, purpose } =
+    await req.json();
+
+  const token = req.cookies.get('otp_token')?.value;
+  if (!token || !verifyOtpToken(token, email, otp)) {
+    return NextResponse.json(
+      { error: '인증번호가 올바르지 않거나 만료되었습니다.' },
+      { status: 400 }
+    );
+  }
+
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.SUPABASE_SERVICE_ROLE_KEY
+  ) {
+    return NextResponse.json(
+      { error: '서버 설정 오류: Supabase 키가 누락되었습니다.' },
+      { status: 500 }
+    );
+  }
+
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+
+  const { error } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: {
+      name,
+      role,
+      ...(role === 'teacher' ? { organization, purpose } : {}),
+    },
+  });
+
+  if (error) {
+    console.error('Supabase createUser error:', error);
+    const message =
+      error.message === 'User already registered'
+        ? '이미 가입된 이메일입니다.'
+        : '회원가입에 실패했습니다.';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const response = NextResponse.json({ success: true });
+  response.cookies.delete('otp_token');
+  return response;
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -17,9 +17,12 @@ function hashOtp(otp: string): string {
 
 function verifyOtpToken(token: string, email: string, otp: string): boolean {
   try {
-    const { email: te, otpHash, expiresAt, sig }: OtpToken = JSON.parse(
-      Buffer.from(token, 'base64').toString()
-    );
+    const {
+      email: te,
+      otpHash,
+      expiresAt,
+      sig,
+    }: OtpToken = JSON.parse(Buffer.from(token, 'base64').toString());
 
     if (te !== email) return false;
     if (Date.now() > expiresAt) return false;
@@ -33,10 +36,7 @@ function verifyOtpToken(token: string, email: string, otp: string): boolean {
       return false;
 
     const inputHash = hashOtp(otp);
-    return crypto.timingSafeEqual(
-      Buffer.from(otpHash),
-      Buffer.from(inputHash)
-    );
+    return crypto.timingSafeEqual(Buffer.from(otpHash), Buffer.from(inputHash));
   } catch {
     return false;
   }

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -6,29 +6,37 @@ const OTP_SECRET = process.env.OTP_SECRET!;
 
 interface OtpToken {
   email: string;
-  otp: string;
+  otpHash: string;
   expiresAt: number;
   sig: string;
 }
 
+function hashOtp(otp: string): string {
+  return crypto.createHmac('sha256', OTP_SECRET).update(otp).digest('hex');
+}
+
 function verifyOtpToken(token: string, email: string, otp: string): boolean {
   try {
-    const {
-      email: te,
-      otp: to,
-      expiresAt,
-      sig,
-    }: OtpToken = JSON.parse(Buffer.from(token, 'base64').toString());
+    const { email: te, otpHash, expiresAt, sig }: OtpToken = JSON.parse(
+      Buffer.from(token, 'base64').toString()
+    );
 
-    if (te !== email || to !== otp) return false;
+    if (te !== email) return false;
     if (Date.now() > expiresAt) return false;
 
-    const payload = `${te}:${to}:${expiresAt}`;
+    const payload = `${te}:${otpHash}:${expiresAt}`;
     const expected = crypto
       .createHmac('sha256', OTP_SECRET)
       .update(payload)
       .digest('hex');
-    return crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+    if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected)))
+      return false;
+
+    const inputHash = hashOtp(otp);
+    return crypto.timingSafeEqual(
+      Buffer.from(otpHash),
+      Buffer.from(inputHash)
+    );
   } catch {
     return false;
   }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,10 +3,44 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Mail, Lock, Eye, EyeOff } from 'lucide-react';
+import { createClient } from '@/lib/supabase/client';
+import { getAuthErrorMessage } from '@/lib/supabase/authErrors';
 
 export default function LoginPage() {
+  const router = useRouter();
+  const supabase = createClient();
+
   const [showPassword, setShowPassword] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleLogin = async () => {
+    setErrorMessage(null);
+
+    if (!email || !password) {
+      setErrorMessage('이메일과 비밀번호를 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    setIsSubmitting(false);
+
+    if (error) {
+      setErrorMessage(getAuthErrorMessage(error));
+      return;
+    }
+
+    router.replace('/');
+    router.refresh();
+  };
 
   return (
     <main className="flex min-h-screen flex-1 items-center justify-center bg-[#faf7f2] px-4 py-12">
@@ -57,7 +91,13 @@ export default function LoginPage() {
           </div>
 
           {/* 폼 */}
-          <div className="flex flex-col gap-4">
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleLogin();
+            }}
+          >
             {/* 이메일 */}
             <div className="flex flex-col gap-2">
               <label className="text-secondary text-[14px] font-medium">
@@ -69,6 +109,8 @@ export default function LoginPage() {
                 </div>
                 <input
                   type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
                   placeholder="example@email.com"
                   className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 h-12.5 w-full rounded-[14px] border bg-[#faf7f2] pr-4 pl-10 text-[16px] transition-all outline-none focus:ring-2"
                 />
@@ -86,6 +128,8 @@ export default function LoginPage() {
                 </div>
                 <input
                   type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
                   placeholder="비밀번호를 입력하세요"
                   className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 h-12.5 w-full rounded-[14px] border bg-[#faf7f2] pr-12 pl-10 text-[16px] transition-all outline-none focus:ring-2"
                 />
@@ -103,26 +147,20 @@ export default function LoginPage() {
               </div>
             </div>
 
-            {/* 로그인 버튼 */}
-            <button className="bg-primary mt-2 h-13 w-full rounded-[14px] text-[16px] font-semibold text-white shadow-[0px_1px_3px_0px_rgba(0,0,0,0.1),0px_1px_2px_0px_rgba(0,0,0,0.1)] transition-all hover:bg-[#e5aa35] active:scale-[0.99]">
-              로그인
-            </button>
-          </div>
+            {/* 에러 메시지 */}
+            {errorMessage && (
+              <p className="text-[14px] text-red-500">{errorMessage}</p>
+            )}
 
-          {/* 데모 계정
-          <div className="mt-6 flex flex-col gap-3">
-            <p className="text-secondary/40 text-center text-[12px]">
-              — 데모 계정으로 빠른 시작 —
-            </p>
-            <div className="flex gap-2">
-              <button className="border-secondary/8 text-secondary hover:bg-secondary/5 h-10.5 flex-1 rounded-[14px] border bg-[#faf7f2] text-[14px] font-medium transition-colors">
-                🎨 선생님 계정
-              </button>
-              <button className="border-secondary/8 text-secondary hover:bg-secondary/5 h-10.5 flex-1 rounded-[14px] border bg-[#faf7f2] text-[14px] font-medium transition-colors">
-                👤 일반 계정
-              </button>
-            </div>
-          </div> */}
+            {/* 로그인 버튼 */}
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="bg-primary mt-2 h-13 w-full rounded-[14px] text-[16px] font-semibold text-white shadow-[0px_1px_3px_0px_rgba(0,0,0,0.1),0px_1px_2px_0px_rgba(0,0,0,0.1)] transition-all hover:bg-[#e5aa35] active:scale-[0.99] disabled:opacity-60"
+            >
+              {isSubmitting ? '로그인 중...' : '로그인'}
+            </button>
+          </form>
 
           {/* 회원가입 링크 */}
           <p className="text-secondary/50 mt-6 text-center text-[14px]">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -135,6 +135,7 @@ export default function LoginPage() {
                 />
                 <button
                   type="button"
+                  tabIndex={-1}
                   onClick={() => setShowPassword(!showPassword)}
                   className="text-secondary/40 hover:text-secondary/70 absolute top-1/2 right-3.5 -translate-y-1/2 transition-colors"
                 >

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -287,6 +287,7 @@ export default function SignupPage() {
                     />
                     <button
                       type="button"
+                      tabIndex={-1}
                       onClick={() => setShowPassword(!showPassword)}
                       className="text-secondary/40 hover:text-secondary/70 absolute top-1/2 right-3.5 -translate-y-1/2 transition-colors"
                     >
@@ -317,6 +318,7 @@ export default function SignupPage() {
                     />
                     <button
                       type="button"
+                      tabIndex={-1}
                       onClick={() =>
                         setShowConfirmPassword(!showConfirmPassword)
                       }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -51,16 +51,16 @@ export default function SignupPage() {
     }
 
     setIsSendingOtp(true);
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        shouldCreateUser: true,
-      },
+    const res = await fetch('/api/auth/send-otp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
     });
     setIsSendingOtp(false);
 
-    if (error) {
-      setErrorMessage(getAuthErrorMessage(error));
+    if (!res.ok) {
+      const { error } = await res.json();
+      setErrorMessage(error ?? '이메일 발송에 실패했습니다.');
       return;
     }
 
@@ -99,31 +99,42 @@ export default function SignupPage() {
 
     setIsSubmitting(true);
 
-    const { error: verifyError } = await supabase.auth.verifyOtp({
-      email,
-      token: otp,
-      type: 'email',
+    const signupRes = await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email,
+        otp,
+        password,
+        name,
+        role: userType,
+        organization,
+        purpose,
+      }),
     });
 
-    if (verifyError) {
+    if (!signupRes.ok) {
       setIsSubmitting(false);
-      setErrorMessage(getAuthErrorMessage(verifyError));
+      try {
+        const { error } = await signupRes.json();
+        setErrorMessage(error ?? '회원가입에 실패했습니다.');
+      } catch {
+        setErrorMessage('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
       return;
     }
 
-    const { error: updateError } = await supabase.auth.updateUser({
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
       password,
-      data: {
-        name,
-        role: userType,
-        ...(userType === 'teacher' ? { organization, purpose } : {}),
-      },
     });
 
     setIsSubmitting(false);
 
-    if (updateError) {
-      setErrorMessage(getAuthErrorMessage(updateError));
+    if (signInError) {
+      setErrorMessage(
+        `가입은 완료됐으나 로그인에 실패했습니다. (${getAuthErrorMessage(signInError)}) 로그인 페이지에서 다시 시도해주세요.`
+      );
       return;
     }
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -116,9 +116,7 @@ export default function SignupPage() {
       data: {
         name,
         role: userType,
-        ...(userType === 'teacher'
-          ? { organization, purpose }
-          : {}),
+        ...(userType === 'teacher' ? { organization, purpose } : {}),
       },
     });
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -15,6 +15,7 @@ import {
   Building2,
 } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
+import { getAuthErrorMessage } from '@/lib/supabase/authErrors';
 
 type UserType = 'general' | 'teacher';
 
@@ -59,7 +60,7 @@ export default function SignupPage() {
     setIsSendingOtp(false);
 
     if (error) {
-      setErrorMessage(error.message);
+      setErrorMessage(getAuthErrorMessage(error));
       return;
     }
 
@@ -106,7 +107,7 @@ export default function SignupPage() {
 
     if (verifyError) {
       setIsSubmitting(false);
-      setErrorMessage(verifyError.message);
+      setErrorMessage(getAuthErrorMessage(verifyError));
       return;
     }
 
@@ -124,7 +125,7 @@ export default function SignupPage() {
     setIsSubmitting(false);
 
     if (updateError) {
-      setErrorMessage(updateError.message);
+      setErrorMessage(getAuthErrorMessage(updateError));
       return;
     }
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
   User,
@@ -13,14 +14,123 @@ import {
   CheckCircle,
   Building2,
 } from 'lucide-react';
+import { createClient } from '@/lib/supabase/client';
 
 type UserType = 'general' | 'teacher';
 
 export default function SignupPage() {
+  const router = useRouter();
+  const supabase = createClient();
+
   const [userType, setUserType] = useState<UserType>('general');
   const [emailSent, setEmailSent] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [otp, setOtp] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [organization, setOrganization] = useState('');
+  const [purpose, setPurpose] = useState('');
+
+  const [isSendingOtp, setIsSendingOtp] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [infoMessage, setInfoMessage] = useState<string | null>(null);
+
+  const handleSendOtp = async () => {
+    setErrorMessage(null);
+    setInfoMessage(null);
+
+    if (!email) {
+      setErrorMessage('이메일을 입력해주세요.');
+      return;
+    }
+
+    setIsSendingOtp(true);
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        shouldCreateUser: true,
+      },
+    });
+    setIsSendingOtp(false);
+
+    if (error) {
+      setErrorMessage(error.message);
+      return;
+    }
+
+    setEmailSent(true);
+    setInfoMessage('인증번호를 이메일로 발송했습니다.');
+  };
+
+  const handleSignup = async () => {
+    setErrorMessage(null);
+    setInfoMessage(null);
+
+    if (!name.trim()) {
+      setErrorMessage('이름을 입력해주세요.');
+      return;
+    }
+    if (!emailSent) {
+      setErrorMessage('이메일 인증을 먼저 진행해주세요.');
+      return;
+    }
+    if (!otp || otp.length !== 8) {
+      setErrorMessage('8자리 인증번호를 입력해주세요.');
+      return;
+    }
+    if (password.length < 6) {
+      setErrorMessage('비밀번호는 6자 이상이어야 합니다.');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setErrorMessage('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    if (userType === 'teacher' && !organization.trim()) {
+      setErrorMessage('교육기관명을 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const { error: verifyError } = await supabase.auth.verifyOtp({
+      email,
+      token: otp,
+      type: 'email',
+    });
+
+    if (verifyError) {
+      setIsSubmitting(false);
+      setErrorMessage(verifyError.message);
+      return;
+    }
+
+    const { error: updateError } = await supabase.auth.updateUser({
+      password,
+      data: {
+        name,
+        role: userType,
+        ...(userType === 'teacher'
+          ? { organization, purpose }
+          : {}),
+      },
+    });
+
+    setIsSubmitting(false);
+
+    if (updateError) {
+      setErrorMessage(updateError.message);
+      return;
+    }
+
+    router.replace('/');
+    router.refresh();
+  };
 
   return (
     <main className="flex min-h-screen flex-1 items-center justify-center bg-[#FAF7F2] px-4 pt-28 pb-12">
@@ -89,6 +199,8 @@ export default function SignupPage() {
                     </div>
                     <input
                       type="text"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
                       placeholder="이름을 입력하세요"
                       className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 h-12.5 w-full rounded-[14px] border bg-[#faf7f2] pr-4 pl-10 text-[16px] transition-all outline-none focus:ring-2"
                     />
@@ -107,15 +219,23 @@ export default function SignupPage() {
                       </div>
                       <input
                         type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
                         placeholder="example@email.com"
                         className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 h-12.5 w-full rounded-[14px] border bg-[#faf7f2] pr-4 pl-10 text-[16px] transition-all outline-none focus:ring-2"
                       />
                     </div>
                     <button
-                      onClick={() => setEmailSent(true)}
-                      className="bg-primary/10 text-primary hover:bg-primary/20 h-12.5 rounded-[14px] px-4 text-[14px] font-medium whitespace-nowrap transition-colors"
+                      type="button"
+                      onClick={handleSendOtp}
+                      disabled={isSendingOtp}
+                      className="bg-primary/10 text-primary hover:bg-primary/20 h-12.5 rounded-[14px] px-4 text-[14px] font-medium whitespace-nowrap transition-colors disabled:opacity-60"
                     >
-                      {emailSent ? '재발송' : '인증발송'}
+                      {isSendingOtp
+                        ? '발송 중...'
+                        : emailSent
+                          ? '재발송'
+                          : '인증발송'}
                     </button>
                   </div>
                 </div>
@@ -130,8 +250,12 @@ export default function SignupPage() {
                       <input
                         type="text"
                         inputMode="numeric"
-                        maxLength={6}
-                        placeholder="인증번호 6자리 입력"
+                        maxLength={8}
+                        value={otp}
+                        onChange={(e) =>
+                          setOtp(e.target.value.replace(/\D/g, ''))
+                        }
+                        placeholder="인증번호 8자리 입력"
                         className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 h-12.5 flex-1 rounded-[14px] border bg-[#faf7f2] px-4 text-[16px] transition-all outline-none focus:ring-2"
                       />
                       <div className="flex shrink-0 items-center gap-1">
@@ -155,6 +279,8 @@ export default function SignupPage() {
                     </div>
                     <input
                       type={showPassword ? 'text' : 'password'}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
                       placeholder="6자 이상"
                       className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 h-12.5 w-full rounded-[14px] border bg-[#faf7f2] pr-12 pl-10 text-[16px] transition-all outline-none focus:ring-2"
                     />
@@ -183,6 +309,8 @@ export default function SignupPage() {
                     </div>
                     <input
                       type={showConfirmPassword ? 'text' : 'password'}
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
                       placeholder="비밀번호 재입력"
                       className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 h-12.5 w-full rounded-[14px] border bg-[#faf7f2] pr-12 pl-10 text-[16px] transition-all outline-none focus:ring-2"
                     />
@@ -229,6 +357,8 @@ export default function SignupPage() {
                         </div>
                         <input
                           type="text"
+                          value={organization}
+                          onChange={(e) => setOrganization(e.target.value)}
                           placeholder="학원 / 학교명"
                           className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 h-12.5 w-full rounded-[14px] border bg-[#faf7f2] pr-4 pl-10 text-[16px] transition-all outline-none focus:ring-2"
                         />
@@ -241,6 +371,8 @@ export default function SignupPage() {
                         사용 목적
                       </label>
                       <textarea
+                        value={purpose}
+                        onChange={(e) => setPurpose(e.target.value)}
                         placeholder="사용 목적을 간략하게 작성해주세요"
                         rows={4}
                         className="border-secondary/5 text-secondary placeholder:text-secondary/30 focus:border-primary/40 focus:ring-primary/30 w-full resize-none rounded-[14px] border bg-[#faf7f2] px-4 py-3 text-[16px] leading-6 transition-all outline-none focus:ring-2"
@@ -251,9 +383,25 @@ export default function SignupPage() {
               </AnimatePresence>
             </div>
 
+            {/* 메시지 영역 */}
+            {(errorMessage || infoMessage) && (
+              <p
+                className={`text-[14px] ${
+                  errorMessage ? 'text-red-500' : 'text-[#00c950]'
+                }`}
+              >
+                {errorMessage ?? infoMessage}
+              </p>
+            )}
+
             {/* 회원가입 버튼 */}
-            <button className="bg-primary h-13 w-full rounded-[14px] text-[16px] font-semibold text-white shadow-[0px_1px_3px_0px_rgba(0,0,0,0.1),0px_1px_2px_0px_rgba(0,0,0,0.1)] transition-all hover:bg-[#e5aa35] active:scale-[0.99]">
-              회원가입 완료
+            <button
+              type="button"
+              onClick={handleSignup}
+              disabled={isSubmitting}
+              className="bg-primary h-13 w-full rounded-[14px] text-[16px] font-semibold text-white shadow-[0px_1px_3px_0px_rgba(0,0,0,0.1),0px_1px_2px_0px_rgba(0,0,0,0.1)] transition-all hover:bg-[#e5aa35] active:scale-[0.99] disabled:opacity-60"
+            >
+              {isSubmitting ? '처리 중...' : '회원가입 완료'}
             </button>
 
             {/* 로그인 링크 */}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,8 +1,16 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
 import { UserMenu } from './userMenu';
 
-export default function Header() {
+export default async function Header() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const name = user?.user_metadata?.name as string | undefined;
+
   return (
     <header className="h-16">
       <div className="border-secondary/8 fixed top-0 z-20 h-16 w-full border-b bg-[#FAF7F2]/95 shadow-[0_2px_8px_rgba(44,40,38,0.06)] backdrop-blur">
@@ -29,21 +37,24 @@ export default function Header() {
           </div>
 
           <div className="flex items-center gap-2">
-            {/* 로그아웃상태
-            <Link
-              href="/login"
-              className="text-secondary hover:bg-primary/10 inline-flex h-9 items-center px-5 py-1.5 text-sm hover:rounded-xl"
-            >
-              로그인
-            </Link>
-            <Link
-              href="/signup"
-              className="bg-primary inline-flex h-9 items-center rounded-xl px-5 text-sm text-white transition-colors hover:bg-[#E09415]"
-            >
-              회원가입
-            </Link> */}
-            {/* //로그아웃 상태 */}
-            <UserMenu name="김관람" />
+            {user && name ? (
+              <UserMenu name={name} />
+            ) : (
+              <>
+                <Link
+                  href="/login"
+                  className="text-secondary hover:bg-primary/10 inline-flex h-9 items-center px-5 py-1.5 text-sm hover:rounded-xl"
+                >
+                  로그인
+                </Link>
+                <Link
+                  href="/signup"
+                  className="bg-primary inline-flex h-9 items-center rounded-xl px-5 text-sm text-white transition-colors hover:bg-[#E09415]"
+                >
+                  회원가입
+                </Link>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/layout/userMenu.tsx
+++ b/src/components/layout/userMenu.tsx
@@ -26,7 +26,11 @@ export function UserMenu({ name }: UserMenuProps) {
   const handleLogout = async () => {
     if (isLoggingOut) return;
     setIsLoggingOut(true);
-    await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      setIsLoggingOut(false);
+      return;
+    }
     window.location.replace('/');
   };
 

--- a/src/components/layout/userMenu.tsx
+++ b/src/components/layout/userMenu.tsx
@@ -11,14 +11,24 @@ import {
   LogOut,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { createClient } from '@/lib/supabase/client';
 
 export interface UserMenuProps {
   name: string;
 }
 
 export function UserMenu({ name }: UserMenuProps) {
+  const supabase = createClient();
   const [open, setOpen] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+
+  const handleLogout = async () => {
+    if (isLoggingOut) return;
+    setIsLoggingOut(true);
+    await supabase.auth.signOut();
+    window.location.replace('/');
+  };
 
   // 외부 클릭 시 닫기
   useEffect(() => {
@@ -70,16 +80,15 @@ export function UserMenu({ name }: UserMenuProps) {
             <li>
               <button
                 type="button"
-                onClick={() => {
-                  setOpen(false);
-                }}
+                onClick={handleLogout}
+                disabled={isLoggingOut}
                 className={cn(
                   'flex w-full cursor-pointer items-center gap-3 rounded-xl p-3 text-sm text-[#E5484D] transition-colors',
-                  'hover:bg-[#FDECEC]'
+                  'hover:bg-[#FDECEC] disabled:opacity-60'
                 )}
               >
                 <LogOut className="h-4 w-4" />
-                로그아웃
+                {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
               </button>
             </li>
           </ul>

--- a/src/lib/supabase/authErrors.ts
+++ b/src/lib/supabase/authErrors.ts
@@ -16,8 +16,7 @@ const AUTH_ERROR_CODE_MAP: Record<string, string> = {
   otp_disabled: 'OTP 인증이 비활성화되어 있습니다.',
   over_email_send_rate_limit:
     '이메일 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.',
-  over_request_rate_limit:
-    '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.',
+  over_request_rate_limit: '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.',
   over_sms_send_rate_limit:
     'SMS 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.',
   bad_jwt: '인증 토큰이 올바르지 않습니다.',
@@ -26,16 +25,26 @@ const AUTH_ERROR_CODE_MAP: Record<string, string> = {
   token_expired: '토큰이 만료되었습니다.',
   captcha_failed: '캡차 인증에 실패했습니다.',
   provider_disabled: '해당 인증 방식이 비활성화되어 있습니다.',
-  unexpected_failure: '예기치 않은 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+  unexpected_failure:
+    '예기치 않은 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
 };
 
 const AUTH_ERROR_MESSAGE_PATTERNS: Array<[RegExp, string]> = [
-  [/token has expired or is invalid/i, '인증번호가 만료되었거나 올바르지 않습니다.'],
+  [
+    /token has expired or is invalid/i,
+    '인증번호가 만료되었거나 올바르지 않습니다.',
+  ],
   [/invalid login credentials/i, '이메일 또는 비밀번호가 올바르지 않습니다.'],
-  [/email rate limit exceeded/i, '이메일 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.'],
+  [
+    /email rate limit exceeded/i,
+    '이메일 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.',
+  ],
   [/user already registered/i, '이미 가입된 이메일입니다.'],
   [/password should be at least/i, '비밀번호는 6자 이상이어야 합니다.'],
-  [/email link is invalid or has expired/i, '인증 링크가 만료되었거나 올바르지 않습니다.'],
+  [
+    /email link is invalid or has expired/i,
+    '인증 링크가 만료되었거나 올바르지 않습니다.',
+  ],
   [/signups not allowed/i, '회원가입이 비활성화되어 있습니다.'],
   [/unable to validate email address/i, '유효하지 않은 이메일 형식입니다.'],
   [/network/i, '네트워크 오류가 발생했습니다. 연결을 확인해주세요.'],

--- a/src/lib/supabase/authErrors.ts
+++ b/src/lib/supabase/authErrors.ts
@@ -1,0 +1,60 @@
+import { AuthError } from '@supabase/supabase-js';
+
+const AUTH_ERROR_CODE_MAP: Record<string, string> = {
+  invalid_credentials: '이메일 또는 비밀번호가 올바르지 않습니다.',
+  email_not_confirmed: '이메일 인증이 완료되지 않았습니다.',
+  email_exists: '이미 가입된 이메일입니다.',
+  user_already_exists: '이미 가입된 사용자입니다.',
+  user_not_found: '존재하지 않는 사용자입니다.',
+  signup_disabled: '회원가입이 비활성화되어 있습니다.',
+  weak_password: '비밀번호가 너무 약합니다. 더 안전한 비밀번호를 입력해주세요.',
+  same_password: '기존 비밀번호와 동일합니다.',
+  validation_failed: '입력값을 확인해주세요.',
+  email_address_invalid: '유효하지 않은 이메일 형식입니다.',
+  email_address_not_authorized: '허용되지 않은 이메일 주소입니다.',
+  otp_expired: '인증번호가 만료되었습니다. 다시 발송해주세요.',
+  otp_disabled: 'OTP 인증이 비활성화되어 있습니다.',
+  over_email_send_rate_limit:
+    '이메일 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.',
+  over_request_rate_limit:
+    '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.',
+  over_sms_send_rate_limit:
+    'SMS 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.',
+  bad_jwt: '인증 토큰이 올바르지 않습니다.',
+  session_expired: '세션이 만료되었습니다. 다시 로그인해주세요.',
+  session_not_found: '세션을 찾을 수 없습니다. 다시 로그인해주세요.',
+  token_expired: '토큰이 만료되었습니다.',
+  captcha_failed: '캡차 인증에 실패했습니다.',
+  provider_disabled: '해당 인증 방식이 비활성화되어 있습니다.',
+  unexpected_failure: '예기치 않은 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+};
+
+const AUTH_ERROR_MESSAGE_PATTERNS: Array<[RegExp, string]> = [
+  [/token has expired or is invalid/i, '인증번호가 만료되었거나 올바르지 않습니다.'],
+  [/invalid login credentials/i, '이메일 또는 비밀번호가 올바르지 않습니다.'],
+  [/email rate limit exceeded/i, '이메일 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.'],
+  [/user already registered/i, '이미 가입된 이메일입니다.'],
+  [/password should be at least/i, '비밀번호는 6자 이상이어야 합니다.'],
+  [/email link is invalid or has expired/i, '인증 링크가 만료되었거나 올바르지 않습니다.'],
+  [/signups not allowed/i, '회원가입이 비활성화되어 있습니다.'],
+  [/unable to validate email address/i, '유효하지 않은 이메일 형식입니다.'],
+  [/network/i, '네트워크 오류가 발생했습니다. 연결을 확인해주세요.'],
+];
+
+export function getAuthErrorMessage(
+  error: AuthError | { code?: string; message?: string } | null | undefined
+): string {
+  if (!error) return '알 수 없는 오류가 발생했습니다.';
+
+  const code = 'code' in error ? error.code : undefined;
+  if (code && AUTH_ERROR_CODE_MAP[code]) {
+    return AUTH_ERROR_CODE_MAP[code];
+  }
+
+  const message = error.message ?? '';
+  for (const [pattern, korean] of AUTH_ERROR_MESSAGE_PATTERNS) {
+    if (pattern.test(message)) return korean;
+  }
+
+  return '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+}


### PR DESCRIPTION
## 📌 개요

회원가입·로그인·로그아웃 인증 흐름과 전시회 생성·관람 페이지를 구현했습니다.
Supabase Auth + Resend 이메일 OTP 인증을 연동하고, 인증 상태에 따라 헤더 UI를 조건부로 렌더링합니다.

## 🔍 변경 사항

**인증 (Auth)**
- 회원가입 API 구현 (`/api/auth/signup`): Supabase Admin API로 사용자 생성, 역할별 메타데이터 저장
- 이메일 OTP 인증 API 구현 (`/api/auth/send-otp`): Resend로 인증번호 발송, HMAC-SHA256 해시 후 httpOnly 쿠키 저장 (유효 10분)
- OTP 검증에 `crypto.timingSafeEqual` 적용으로 타이밍 어택 방지
- Supabase 인증 오류 메시지 한국어 매핑 (`src/lib/supabase/authErrors.ts`)
- 헤더 조건부 렌더링: 서버 컴포넌트에서 `getUser()`로 인증 상태 확인 후 로그인 상태면 UserMenu, 비로그인 상태면 로그인·회원가입 버튼 표시
- UserMenu 로그아웃 기능 연결: `supabase.auth.signOut()` 호출, 중복 클릭 방지 및 로딩 상태 표시

## 🔗 관련 이슈 번호

- close #28

## 📸 스크린샷 (UI 변경 시 필수)

### 로그인 전
<img width="2832" height="314" alt="스크린샷 2026-04-29 오후 3 45 56" src="https://github.com/user-attachments/assets/356be5bc-c271-46c9-818f-452b8fe09758" />

### 로그인 후
<img width="2836" height="246" alt="스크린샷 2026-04-29 오후 3 46 07" src="https://github.com/user-attachments/assets/813b9de6-f24f-4efd-bfe2-a63b416150e0" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

* resend 이메일 발송이 하루에 100회 제한이라서 계정 생성하고 테스트하기 충분하다고 생각합니다.
* 선생님 계정 회원 가입 할 때 데이터를 db에 저장해야 하는데 일단 현재는 auth.user에 메타데이터로 저장한 상태입니다. 이후 db 초기화한 후에 db 저장 로직으로 변경할 예정입니다.