### PR TITLE
[PR] 회원가입 시 계정 정보를 Supabase DB에 데이터 저장

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -75,9 +75,10 @@ export async function POST(req: NextRequest) {
     password,
     email_confirm: true,
     user_metadata: {
-      name,
+      username: name,
       role,
-      ...(role === 'teacher' ? { organization, purpose } : {}),
+      institution: role === 'teacher' ? organization : null,
+      purpose: role === 'teacher' ? purpose : null,
     },
   });
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = 'force-dynamic';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -19,8 +19,11 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const submissionLockRef = useRef(false);
 
   const handleLogin = async () => {
+    if (submissionLockRef.current) return;
+
     setErrorMessage(null);
 
     if (!email || !password) {
@@ -28,14 +31,16 @@ export default function LoginPage() {
       return;
     }
 
+    submissionLockRef.current = true;
     setIsSubmitting(true);
     const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
     });
-    setIsSubmitting(false);
 
     if (error) {
+      submissionLockRef.current = false;
+      setIsSubmitting(false);
       setErrorMessage(getAuthErrorMessage(error));
       return;
     }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = 'force-dynamic';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -42,6 +42,7 @@ export default function SignupPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [infoMessage, setInfoMessage] = useState<string | null>(null);
+  const submissionLockRef = useRef(false);
 
   const handleSendOtp = async () => {
     setErrorMessage(null);
@@ -71,6 +72,8 @@ export default function SignupPage() {
   };
 
   const handleSignup = async () => {
+    if (submissionLockRef.current) return;
+
     setErrorMessage(null);
     setInfoMessage(null);
 
@@ -99,6 +102,7 @@ export default function SignupPage() {
       return;
     }
 
+    submissionLockRef.current = true;
     setIsSubmitting(true);
 
     const signupRes = await fetch('/api/auth/signup', {
@@ -116,6 +120,7 @@ export default function SignupPage() {
     });
 
     if (!signupRes.ok) {
+      submissionLockRef.current = false;
       setIsSubmitting(false);
       try {
         const { error } = await signupRes.json();
@@ -131,9 +136,9 @@ export default function SignupPage() {
       password,
     });
 
-    setIsSubmitting(false);
-
     if (signInError) {
+      submissionLockRef.current = false;
+      setIsSubmitting(false);
       setErrorMessage(
         `가입은 완료됐으나 로그인에 실패했습니다. (${getAuthErrorMessage(signInError)}) 로그인 페이지에서 다시 시도해주세요.`
       );

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -9,7 +9,20 @@ export default async function Header() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  const name = user?.user_metadata?.name as string | undefined;
+  let name: string | undefined =
+    user?.user_metadata?.username ?? user?.email?.split('@')[0];
+
+  if (user) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('username')
+      .eq('id', user.id)
+      .maybeSingle();
+
+    name = profile?.username ?? name;
+  }
+
+  const displayName = name?.trim() || '사용자';
 
   return (
     <header className="h-16">
@@ -37,8 +50,8 @@ export default async function Header() {
           </div>
 
           <div className="flex items-center gap-2">
-            {user && name ? (
-              <UserMenu name={name} />
+            {user ? (
+              <UserMenu name={displayName} />
             ) : (
               <>
                 <Link


### PR DESCRIPTION
## 📌 개요

DB 초기화 및 변경된 user_metadata 구조에 맞춰 회원가입 및 로그인 로직을 수정하고, 사용자 경험 개선을 위해 중복 제출 방지 및 사용자명 표시 로직을 개선했습니다.

## 🔍 변경 사항

- 회원가입 API에서 user_metadata 구조 변경 (`name` → `username`, `institution`, `purpose` 필드 추가)
- 로그인/회원가입 페이지에 중복 제출 방지 로직 추가 (`submissionLockRef` 활용)
- Header 컴포넌트의 사용자명 표시 로직 개선:
  - `profiles` 테이블에서 username 조회
  - fallback으로 user_metadata.username 또는 이메일 앞부분 사용
  - 기본값으로 '사용자' 표시

## 🔗 관련 이슈 번호

- close #33

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경 사항 없음 (로직 수정)

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- 테스트용 선생님, 일반 계정을 만들어놨습니다. 디스코드 채팅에 상세 정보 남겨놨으니 UI 테스트할 때 사용하시면 되겠습니다.