### PR TITLE
[PR] 위시리스트 페이지 퍼블리싱

### DIFF
--- a/src/app/wishList/page.tsx
+++ b/src/app/wishList/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import WishlistCard from '@/components/myArtworks/ArtworkCard';
+import WishlistCard from '@/components/wishList/WishlistCard';
 import ArtworkModal from '@/components/myArtworks/ArtworkModal';
 import FilterTab from '@/components/myArtworks/FilterTab';
 import { WISHLIST_ARTWORKS } from '@/components/wishList/MockData';

--- a/src/app/wishList/page.tsx
+++ b/src/app/wishList/page.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import WishlistCard from '@/components/wishlist/WishlistCard';
+import ArtworkModal from '@/components/myArtworks/ArtworkModal';
+import FilterTab from '@/components/myArtworks/FilterTab';
+import { WISHLIST_ARTWORKS } from '@/components/wishlist/MockData';
+import { Artwork, FilterType } from '@/components/myArtworks/Types';
+
+export default function WishlistPage() {
+  const [filter, setFilter] = useState<FilterType>('latest');
+  const [selectedArtwork, setSelectedArtwork] = useState<Artwork | null>(null);
+
+  const sorted = [...WISHLIST_ARTWORKS].sort((a, b) => {
+    if (filter === 'latest')
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    if (filter === 'oldest')
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    return b.likesCount - a.likesCount;
+  });
+
+  return (
+    <>
+      <main className="min-h-screen bg-[#F5F0E8]">
+        <div className="mx-auto max-w-[1080px] px-6 py-10">
+          <div className="mb-6">
+            <h1 className="mb-1 text-[28px] font-bold tracking-tight text-[#1A1A1A]">
+              위시리스트
+            </h1>
+            <p className="text-[14px] text-[#888780]">
+              저장한 작품 {WISHLIST_ARTWORKS.length}점
+            </p>
+          </div>
+
+          <FilterTab value={filter} onChange={setFilter} />
+
+          {sorted.length > 0 ? (
+            <div className="grid grid-cols-4 gap-5">
+              {sorted.map((artwork) => (
+                <WishlistCard
+                  key={artwork.id}
+                  artwork={artwork}
+                  onClick={() => setSelectedArtwork(artwork)}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-32">
+              <p className="text-[15px] font-medium text-[#888780]">
+                저장한 작품이 없습니다.
+              </p>
+            </div>
+          )}
+        </div>
+      </main>
+
+      {selectedArtwork && (
+        <ArtworkModal
+          artwork={selectedArtwork}
+          onClose={() => setSelectedArtwork(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/wishList/page.tsx
+++ b/src/app/wishList/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useState } from 'react';
-import WishlistCard from '@/components/wishlist/WishlistCard';
+import WishlistCard from '@/components/myArtworks/ArtworkCard';
 import ArtworkModal from '@/components/myArtworks/ArtworkModal';
 import FilterTab from '@/components/myArtworks/FilterTab';
-import { WISHLIST_ARTWORKS } from '@/components/wishlist/MockData';
+import { WISHLIST_ARTWORKS } from '@/components/wishList/MockData';
 import { Artwork, FilterType } from '@/components/myArtworks/Types';
 
 export default function WishlistPage() {

--- a/src/components/layout/userMenu.tsx
+++ b/src/components/layout/userMenu.tsx
@@ -69,10 +69,13 @@ export function UserMenu({ name }: UserMenuProps) {
       {open && (
         <div className="absolute top-full right-0 z-10 w-52 overflow-hidden rounded-xl border border-[#E8DFC8] bg-white p-2 shadow-lg">
           <ul>
-            <MenuItem href="/" icon={<User className="h-4 w-4" />}>
+            <MenuItem href="/myPage" icon={<User className="h-4 w-4" />}>
               마이페이지
             </MenuItem>
-            <MenuItem href="/" icon={<BookMarked className="h-4 w-4" />}>
+            <MenuItem
+              href="/wishList"
+              icon={<BookMarked className="h-4 w-4" />}
+            >
               위시리스트
             </MenuItem>
             <MenuItem href="/artworks" icon={<Heart className="h-4 w-4" />}>

--- a/src/components/wishList/MockData.ts
+++ b/src/components/wishList/MockData.ts
@@ -1,0 +1,16 @@
+import { Artwork } from '@/components/myArtworks/Types';
+
+export const WISHLIST_ARTWORKS: Artwork[] = [
+  {
+    id: '7',
+    title: '바다의 노래',
+    artist: '최지민',
+    description:
+      '제주도 여행에서 바라본 에메랄드빛 바다를 담았습니다. 파도 소리가 들리는 것 같은 그림을 그리고 싶었어요.',
+    exhibitionTitle: '봄의 소리전',
+    academyName: '해피아트 미술학원',
+    imageUrl: '/gallery/painting.png',
+    likesCount: 31,
+    createdAt: '2025-03-25',
+  },
+];

--- a/src/components/wishList/WishlistCard.tsx
+++ b/src/components/wishList/WishlistCard.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Image from 'next/image';
+import { Artwork } from '@/components/myArtworks/Types';
+
+interface WishlistCardProps {
+  artwork: Artwork;
+  onClick: () => void;
+}
+
+export default function WishlistCard({ artwork, onClick }: WishlistCardProps) {
+  return (
+    <div
+      onClick={onClick}
+      className="group cursor-pointer overflow-hidden rounded-2xl border border-[#EDEBE4] bg-white transition-shadow duration-200 hover:shadow-[0_4px_20px_rgba(0,0,0,0.10)]"
+    >
+      <div className="relative aspect-4/3 w-full overflow-hidden bg-[#F3F4F6]">
+        <Image
+          src={artwork.imageUrl}
+          alt={artwork.title}
+          fill
+          className="object-cover transition-transform duration-300 group-hover:scale-105"
+          sizes="(max-width: 1080px) 25vw, 270px"
+        />
+      </div>
+
+      <div className="px-4 py-3.5">
+        <p className="mb-0.5 truncate text-[15px] font-semibold text-[#1A1A1A]">
+          {artwork.title}
+        </p>
+
+        <p className="mb-2 truncate text-[12px] text-[#BCBAB2]">
+          {artwork.artist}
+        </p>
+
+        <div className="flex items-center gap-1 text-[#BCBAB2]">
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+            <path
+              d="M8 13.5S2 9.8 2 5.9A3.4 3.4 0 018 3.6 3.4 3.4 0 0114 5.9C14 9.8 8 13.5 8 13.5z"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span className="text-[12px]">{artwork.likesCount}</span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 개요

위시리스트 페이지 퍼블리싱을 진행했습니다.
사용자가 좋아요를 누른 작품을 한눈에 확인하고, 카드 클릭 시 작품 상세 모달을 통해 상세 정보를 볼 수 있습니다.

## 🔍 변경 사항

- 카드 컴포넌트 구현 (작품명 / 작가명 / 좋아요 수 표시)
- 기존 FilterTab, ArtworkModal 컴포넌트 재사용 (최신순 / 오래된 순 / 인기순 필터 및 상세 모달)

## 🔗 관련 이슈 번호

close #38 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="2944" height="1782" alt="localhost_3000_wishList" src="https://github.com/user-attachments/assets/5a389087-fd6d-4d41-ba74-f070ab093a97" />



<img width="1141" height="773" alt="스크린샷 2026-05-04 오후 12 21 51" src="https://github.com/user-attachments/assets/b370d465-ccfe-4776-bfbf-e178a3c72353" />

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

목업 데이터를 기반으로 진행한 퍼블리싱입니다!