### PR TITLE
[PR] 메인 페이지 필터 버튼이 눌리지 않는 버그 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
           width={920}
           height={425}
           priority
-          className="absolute top-0 left-1/2 -z-10 h-auto w-[60%] -translate-x-1/2"
+          className="pointer-events-none absolute top-0 left-1/2 -z-10 h-auto w-[60%] -translate-x-1/2"
         />
         <div className="mx-auto max-w-6xl px-3.5 py-20 text-center">
           {/* hero title, text */}

--- a/src/components/home/exhibitionList.tsx
+++ b/src/components/home/exhibitionList.tsx
@@ -39,7 +39,7 @@ export default function ExhibitionList({
         {/* 선생님 계정만 추가 */}
         {isTeacher && (
           <Link
-            href="/exhibitions/new"
+            href="/exhibitions/create"
             className="bg-primary inline-flex items-center gap-1.5 rounded-full px-5 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#E09415]"
           >
             <Plus className="h-4 w-4" />


### PR DESCRIPTION
## 📌 개요

화면 너비가 2000px이 넘을 때, 메인 페이지에서 필터 버튼이 클릭되지 않는 오류가 발생했습니다. 배경 이미지에 클릭 방지 속성을 추가하여 필터 버튼이 클릭되도록 수정했습니다.

## 🔍 변경 사항

- 메인 페이지 배경 이미지 className에 `pointer-events-none` 속성 추가
- 전시회 만들기 버튼 링크 최신화(exhibitions/new -> exhibitions/create)

## 🔗 관련 이슈 번호

close #49 

## 📸 스크린샷 (UI 변경 시 필수)
UI 변경 없음

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항
