### PR TITLE
[PR] 동적 세그먼트 폴더 [id], [exhibitionId]가 겹치는 오류 수정

### DIFF
--- a/src/app/api/exhibitions/[exhibitionId]/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/route.ts
@@ -4,11 +4,11 @@ import { ExhibitionRow } from '@/types/exhibitionList';
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ exhibitionId: string }> }
 ) {
   try {
     const supabase = await createClient();
-    const { id: exhibitionId } = await params;
+    const { exhibitionId } = await params;
 
     const { data: rawData, error } = await supabase
       .from('exhibitions')


### PR DESCRIPTION
## 📌 개요

`api/exhibitions/` 하위에 `[id]`와 `[exhibitionId]` 두 개의 동적 세그먼트 폴더가 공존하면서 Next.js 라우트 충돌이 발생하는 문제를 수정했습니다. `[id]/route.ts`를 `[exhibitionId]/route.ts`로 이동하고 파라미터 명칭을 통일했습니다.

## 🔍 변경 사항

- `src/app/api/exhibitions/[id]/route.ts` → `src/app/api/exhibitions/[exhibitionId]/route.ts` 로 이동
- 라우트 핸들러 내 params 타입을 `{ id: string }` → `{ exhibitionId: string }` 로 변경

## 🔗 관련 이슈 번호

close #72 

## 📸 스크린샷 (UI 변경 시 필수)

해당 없음

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항