### PR TITLE
[PR] middleware.ts의 matcher 범위 축소

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,15 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // 정적 파일, 이미지 파일 외의 모든 요청에서 updateSession 미들웨어 함수 실행
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    {
+      source:
+        // API 라우트 요청, 정적 파일, 이미지, 아이콘 제외한 모든 요청에서 updateSession 미들웨어 함수 실행
+        '/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|woff|woff2|ttf|otf)$).*)',
+      missing: [
+        // prefetch 요청은 함수 실행 제외
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
   ],
 };

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -26,6 +26,7 @@ export async function updateSession(request: NextRequest) {
   );
 
   const { error } = await supabase.auth.getUser(); // 사용자 정보 불러오며 토큰 갱신 및 쿠키 최신화
+  console.log('middleware: getUser()');
 
   if (error?.code === 'refresh_token_not_found') {
     supabaseResponse.cookies.getAll().forEach(({ name }) => {

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -26,7 +26,6 @@ export async function updateSession(request: NextRequest) {
   );
 
   const { error } = await supabase.auth.getUser(); // 사용자 정보 불러오며 토큰 갱신 및 쿠키 최신화
-  console.log('middleware: getUser()');
 
   if (error?.code === 'refresh_token_not_found') {
     supabaseResponse.cookies.getAll().forEach(({ name }) => {


### PR DESCRIPTION
## 📌 개요

Next.js middleware의 실행 범위가 너무 넓어 불필요한 Supabase `getUser()` 호출이 발생하고 있었습니다. API 라우트, 폰트 파일, prefetch 요청 등을 미들웨어 실행 대상에서 제외해 불필요한 세션 갱신 요청을 줄입니다.

## 🔍 변경 사항

- `middleware.ts` matcher에 `api` 라우트 경로 제외 패턴 추가
- `woff`, `woff2`, `ttf`, `otf` 폰트 파일 요청 제외
- `missing` 조건을 추가해 `next-router-prefetch` 및 `purpose: prefetch` 헤더를 포함한 prefetch 요청에서 미들웨어 실행 제외

## 🔗 관련 이슈 번호

## 📸 스크린샷 (UI 변경 시 필수)

해당 없음 (UI 변경 없음)

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

배포 환경에서 메인 페이지 로딩 시간 확인 결과 코드 작성 이전 평균 4.5초 -> 3초로 줄어든 것을 확인했습니다.