### PR TITLE
[PR] middleware getClaims 기반 세션 갱신 적용

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,8 +9,8 @@ export const config = {
   matcher: [
     {
       source:
-        // API 라우트 요청, 정적 파일, 이미지, 아이콘 제외한 모든 요청에서 updateSession 미들웨어 함수 실행
-        '/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|woff|woff2|ttf|otf)$).*)',
+        // API 라우트, 정적 파일, 이미지, 아이콘, 인증 불필요 페이지 제외
+        '/((?!api|_next/static|_next/image|favicon.ico|login|signup|.*\\.(?:svg|png|jpg|jpeg|gif|webp|woff|woff2|ttf|otf)$).*)',
       missing: [
         // prefetch 요청은 함수 실행 제외
         { type: 'header', key: 'next-router-prefetch' },

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -25,7 +25,7 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  const { error } = await supabase.auth.getUser(); // 사용자 정보 불러오며 토큰 갱신 및 쿠키 최신화
+  const { error } = await supabase.auth.getClaims(); // JWT claims 검증 및 필요 시 토큰 갱신/쿠키 최신화
 
   if (error?.code === 'refresh_token_not_found') {
     supabaseResponse.cookies.getAll().forEach(({ name }) => {


### PR DESCRIPTION
## 📌 개요

Supabase 세션 갱신을 담당하는 middleware의 인증 처리 비용을 줄이기 위해 수정했습니다.

기존에는 middleware에서 `supabase.auth.getUser()`를 호출해 매 요청마다 Supabase Auth 서버에 사용자 정보를 요청했습니다. 하지만 현재 middleware의 목적은 사용자 정보 조회가 아니라 access token 만료 여부 확인 및 필요 시 세션 refresh이므로, `getClaims()` 기반으로 변경해 불필요한 Auth 서버 요청을 줄였습니다.

또한 로그인/회원가입 페이지처럼 인증 세션 갱신이 필요하지 않은 페이지는 middleware 실행 대상에서 제외했습니다.

## 🔍 변경 사항

- `src/lib/supabase/middleware.ts`
  - `supabase.auth.getUser()`를 `supabase.auth.getClaims()`로 변경
  - JWT claims 검증 및 필요 시 세션 refresh가 수행되도록 수정
  - 기존 refresh token 오류 시 Supabase 쿠키 정리 로직은 유지

- `middleware.ts`
  - middleware matcher에서 `/login`, `/signup` 경로 제외
  - API route, static asset, image, favicon, font 파일, prefetch 요청 제외 로직 유지

## 🔗 관련 이슈 번호

- close #84

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경 없음

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?