### PR TITLE
[PR] 바라보고 있는 작품 체크로직 수정

### DIFF
--- a/src/components/galleryExhibition/threejs/Room.tsx
+++ b/src/components/galleryExhibition/threejs/Room.tsx
@@ -127,10 +127,10 @@ export default function Room({
       // const paintingVisible = fovDot > 0.7;
       // mesh.visible = paintingVisible;
 
-      const closestPaintingVisible = fovDot > 0.7 && distance < 7;
+      const closestPaintingVisible = fovDot > 0.5 && distance < 5;
 
       if (closestPaintingVisible) {
-        const score = fovDot * 100 - distance;
+        const score = fovDot * 20 - distance * 10;
 
         if (score > bestScore) {
           bestScore = score;


### PR DESCRIPTION
## 📌 개요

>전시회 관람 페이지에서 작품 좋아요 / 다운로드 시 카메라가 바라보는 작품이 아닌 반대편 작품이 선택되는 문제가 발생.
## 🔍 변경 사항

> 주요 변경 사항을 설명해주세요.


- closestPainting을 결정하는 로직 수정
- 작품을 바라보는 각도 기준을 0.7 → 0.5로 완화하여 범위 확장
- 가장 가까운 작품 선택 점수 계산 방식 수정
기존: 각도 중심 계산
변경: 거리 점수를 높여 가까운 작품이 우선 선택되도록 수정

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #81 

## 📸 스크린샷 (UI 변경 시 필수)

> 변경된 UI 스크린샷을 보여주세요.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
