### PR TITLE
[PR] 종료, 예정된 전시회 입장이 가능한 버그 수정/추가

### DIFF
--- a/src/app/(exhibitions)/gallery/[id]/layout.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/layout.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from 'react';
+import { createClient } from '@/lib/supabase/server';
+import { notFound } from 'next/navigation';
+import { getStatus } from '@/lib/exhibition/dateStatus';
+import { ExhibitionEnded, ExhibitionUpcoming } from '@/components/exhibition';
+import { ExhibitionRow } from '@/types/exhibitionList';
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ id: string }>;
+}) {
+  const { id: exhibitionId } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('exhibitions')
+    .select(
+      'title,start_date,end_date,teacher_id,profile:profiles!teacher_id ( institution )'
+    )
+    .eq('id', exhibitionId)
+    .single<ExhibitionRow>();
+
+  if (error || !data) notFound();
+
+  const { title, start_date, end_date, profile } = data;
+  const status = getStatus(start_date, end_date ?? undefined);
+
+  const institution = Array.isArray(profile)
+    ? profile[0]?.institution
+    : profile?.institution;
+
+  if (status === 'ended')
+    return <ExhibitionEnded title={title} endDate={end_date ?? ''} />;
+  if (status === 'upcoming')
+    return (
+      <ExhibitionUpcoming
+        id={'?'}
+        title={title}
+        host={institution ?? ''}
+        startDate={start_date}
+      />
+    );
+  return <>{children}</>;
+}


### PR DESCRIPTION
## 📌 개요

> 전시회 관람페이지에 종료, 예정일 체크 로직이 없어서 날짜 상관없이 입장이 가능한 버그 발생

## 🔍 변경 사항

> 주요 변경 사항을 설명해주세요.

- layout에서 관람페이지 렌더링 전 date(예정,종료) 체크 & status에 맞는 컴포넌트 렌더링

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #82 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1210" height="705" alt="스크린샷 2026-05-14 오전 9 44 47" src="https://github.com/user-attachments/assets/3d0b1027-2e5e-4ef6-b8e9-5df6db5f22cf" />
<img width="1220" height="684" alt="스크린샷 2026-05-14 오전 9 46 38" src="https://github.com/user-attachments/assets/e8d4b955-97aa-487c-b718-b5498e59204f" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항
