### PR TITLE
[PR] 비로그인 사용자 전시회 입장 불가능한 버그 수정

### DIFF
--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -7,9 +7,12 @@ import { AiOutlineSound } from 'react-icons/ai';
 import ModalWrapper from '@/components/galleryExhibition/threejs/ModalWrapper';
 import { getArtworksByExhibitionId } from '@/service/artworks';
 import Scene2 from '@/components/galleryExhibition/threejs/Scene';
+import { createClient } from '@/lib/supabase/client';
+import { User } from '@supabase/supabase-js';
 
 export default function GalleryExhibitionPage() {
   const { id } = useParams<{ id: string }>();
+  const [user, setUser] = useState<User | null>(null);
   const router = useRouter();
   const [galleryInit, setGalleryInit] = useState([]);
   const [isMuted, setIsMuted] = useState(false);
@@ -21,19 +24,26 @@ export default function GalleryExhibitionPage() {
     [isInitReady, isReady]
   );
   useEffect(() => {
-    const fetchInit = async () => {
+    const run = async () => {
       try {
-        const result = await getArtworksByExhibitionId(id);
-        console.log('rewrewrwe' + result);
-        setGalleryInit(result);
+        const supabase = createClient();
+
+        const [artworksRes, userRes] = await Promise.all([
+          getArtworksByExhibitionId(id),
+          supabase.auth.getUser(),
+        ]);
+
+        setGalleryInit(artworksRes);
+        setUser(userRes.data.user ?? null);
         setIsInitReady(true);
       } catch (error) {
-        console.log(error);
+        console.error(error);
       }
     };
-    fetchInit();
-    // setTimeout(() => setIsInitReady(true), 500);
+
+    run();
   }, [id]);
+
   return (
     <div className={'scr fixed inset-0 z-99'}>
       {!start && (
@@ -141,7 +151,12 @@ export default function GalleryExhibitionPage() {
         className={`h-screen w-screen bg-white ${!start ? 'pointer-events-none opacity-0' : 'pointer-events-auto opacity-100'} `}
       >
         {isInitReady && (
-          <Scene2 exhibitionId={id} ready={setIsReady} init={galleryInit} />
+          <Scene2
+            user={user}
+            exhibitionId={id}
+            ready={setIsReady}
+            init={galleryInit}
+          />
         )}
       </div>
     </div>

--- a/src/app/api/exhibitions/[exhibitionId]/artworks/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/artworks/route.ts
@@ -112,8 +112,8 @@ export async function GET(
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    if (!user)
-      return NextResponse.json({ message: 'no session' }, { status: 401 });
+    // if (!user)
+    //   return NextResponse.json({ message: 'no session' }, { status: 401 });
 
     const { data: artworksRaw, error: artworksError } = await supabase
       .from('artworks')
@@ -141,7 +141,9 @@ export async function GET(
       return {
         ...x,
         likes: artworkLikes.length,
-        likesByMe: artworkLikes.some((xx) => xx.user_id === user.id),
+        likesByMe: user
+          ? artworkLikes.some((xx) => xx.user_id === user.id)
+          : false,
       };
     });
     return NextResponse.json({ message: 'success', artworks }, { status: 200 });

--- a/src/components/galleryExhibition/threejs/Room.tsx
+++ b/src/components/galleryExhibition/threejs/Room.tsx
@@ -9,6 +9,7 @@ import Floor from '@/components/galleryExhibition/threejs/Floor';
 import Walls from '@/components/galleryExhibition/threejs/Walls';
 import InnerWalls from '@/components/galleryExhibition/threejs/InnerWall';
 import Ceiling from '@/components/galleryExhibition/threejs/Ceiling';
+import { User } from '@supabase/supabase-js';
 
 export default function Room({
   init,
@@ -17,6 +18,7 @@ export default function Room({
   walls,
   innerWalls,
   exhibitionId,
+  user,
 }: {
   init: GalleryUIArtworkProps[];
   size: number;
@@ -24,6 +26,7 @@ export default function Room({
   walls: WAllType[];
   innerWalls: WAllType[];
   exhibitionId: string;
+  user: User | null;
 }) {
   const [artworks, setArtworks] = useState(init);
   const [loading, setLoading] = useState(false);
@@ -77,12 +80,11 @@ export default function Room({
       if (!painting) return;
 
       if (e.key === '1') {
-        console.log('id', painting.id);
+        if (!user) return;
         postLikes();
       }
 
       if (e.key === '2') {
-        console.log(painting);
         downloadImgHandler(painting.image_url, painting.title);
       }
     };
@@ -92,7 +94,7 @@ export default function Room({
     return () => {
       window.removeEventListener('keydown', handler);
     };
-  }, [loading, exhibitionId]);
+  }, [loading, exhibitionId, user]);
 
   useFrame(({ camera }) => {
     camera.getWorldDirection(tempCurrentForward.current);

--- a/src/components/galleryExhibition/threejs/Scene.tsx
+++ b/src/components/galleryExhibition/threejs/Scene.tsx
@@ -5,15 +5,18 @@ import { GalleryUIArtworkProps } from '@/types/gallery';
 import { createWalls, generateGalleryWalls } from '@/lib/gallery/createWalls';
 import Room from '@/components/galleryExhibition/threejs/Room';
 import Player from '@/components/galleryExhibition/threejs/Player';
+import { User } from '@supabase/supabase-js';
 
 export default function Scene2({
   exhibitionId,
   ready,
   init,
+  user,
 }: {
   exhibitionId: string;
   ready: Dispatch<SetStateAction<boolean>>;
   init: GalleryUIArtworkProps[];
+  user: User | null;
 }) {
   // console.log(init)
   const size = 21;
@@ -30,6 +33,7 @@ export default function Scene2({
     <>
       <Canvas shadows camera={{ fov: 50 }}>
         <Room
+          user={user}
           exhibitionId={exhibitionId}
           walls={walls}
           innerWalls={innerWalls}

--- a/src/lib/gallery/image.ts
+++ b/src/lib/gallery/image.ts
@@ -7,7 +7,7 @@ export function checkImgSize(
   offset: number
 ) {
   if (!img?.width || !img?.height || img.height === 0) {
-    console.warn('Invalid texture dimensions');
+    // console.warn('Invalid texture dimensions');
     return [w * offset, h * offset];
   }
   const imgAspect = img?.width / img?.height;


### PR DESCRIPTION
## 📌 개요

> 비로그인 사용자가 전시회 입장이 불가능한 버그가 발생했습니다.

## 🔍 변경 사항

> 주요 변경 사항을 설명해주세요.

- gallery/[id]/page 수정
- 기존: artworks만 페칭 
- 수정: user상태 추가, auth.getUser() 추가

- artworks get 요청 수정
- 기존: 유저가 없을경우 nosession 에러 반환
- 수정: 유저가 없을경우에도 정상 진행, 로그인 여부에 따라 likesByMe만 조건부 처리

- artworks handler 수정
- 기존: like toggle 서버에서 처리
- 수정: 클라이언트like handler 에서 유저정보가 없을경우 return 처리

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #88 

## 📸 스크린샷 (UI 변경 시 필수)

> 변경된 UI 스크린샷을 보여주세요.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
