### PR TITLE
[PR] 전시회 종료 상태 계산 로직 수정

### DIFF
--- a/src/lib/exhibition/dateStatus.ts
+++ b/src/lib/exhibition/dateStatus.ts
@@ -14,11 +14,11 @@ export function getStatus(
   }
 
   start.setHours(0, 0, 0, 0);
-  end.setHours(23, 59, 59, 999);
+  end.setHours(0, 0, 0, 0);
 
   if (now < start.getTime()) return 'upcoming';
   if (!endDate) return 'ongoing';
-  if (now > end.getTime()) return 'ended';
+  if (now >= end.getTime()) return 'ended';
   return 'ongoing';
 }
 


### PR DESCRIPTION
## 📌 개요

getStatus 함수의 종료일 경계 계산 오류로 인해, end_date 당일에도 전시회가 '진행중'으로 표시되는 버그를 수정했습니다.

## 🔍 변경 사항

- 'lib/exhibition/dateStatus.ts'의 'getStatus' 함수에서 종료일 판정 기준 수정
- end.setHours(23, 59, 59, 999) -> end.setHours(0, 0, 0, 0)
- now > end --> now >= end
- 종료일 당일 자정부터 '종료' 상태로 판정

## 🔗 관련 이슈 번호

close #90 

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경사항 없습니다

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

'lib/exhibition/dateStatus.ts'는 마이페이지와 전시회 필터 등 여러 곳에서 공통으로 사용 중이므로, 관련 기능 전반에 동일하게 적용됩니다.
