### PR TITLE
[PR] middleware의 파일명 및 함수명을 proxy로 변경

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from 'next/server';
 import { updateSession } from '@/lib/supabase/middleware';
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## 📌 개요

Next.js 16 환경에 맞춰 기존 `middleware.ts` 파일과 `middleware()` 함수의 명칭을 `proxy.ts`, `proxy()`로 변경했습니다.

## 🔍 변경 사항

- `middleware.ts` 파일명을 `proxy.ts`로 변경
- export 함수명을 `middleware`에서 `proxy`로 변경
- 기존 Supabase 세션 갱신 로직과 matcher 설정은 유지

## 🔗 관련 이슈 번호

- close #95

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경 없음

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

기능 동작 변경 없이 Next.js proxy 파일/함수명 규칙에 맞춘 리팩터링입니다.
