### PR TITLE
[PR] 모달팝업 상단부가 헤더에 가려지는 오류 수정

### DIFF
--- a/src/app/(exhibitions)/exhibitions/[id]/manage/page.tsx
+++ b/src/app/(exhibitions)/exhibitions/[id]/manage/page.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { ArrowLeft, Trash2, TriangleAlert, Upload, X } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { Button, buttonVariants } from '@/components/ui/button';
 import {
   AddWorkDialog,
   EditWorkDialog,
@@ -9,6 +9,7 @@ import {
 } from '@/components/exhibition/manage';
 import { notFound, redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
+import { cn } from '@/lib/utils';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -80,14 +81,15 @@ export default async function ExhibitionManagePage({ params }: PageProps) {
 
           <ManageAlertDialog
             trigger={
-              <Button
-                size="lg"
-                variant="destructive"
-                className="shrink-0 rounded-xl"
+              <button
+                className={cn(
+                  buttonVariants({ variant: 'destructive', size: 'lg' }),
+                  'shrink-0 rounded-xl'
+                )}
               >
                 <X className="h-4 w-4" />
                 전시회 종료
-              </Button>
+              </button>
             }
             icon={<TriangleAlert stroke="#FF6900" />}
             iconContainerClassName="bg-primary/10 text-primary"
@@ -166,14 +168,15 @@ export default async function ExhibitionManagePage({ params }: PageProps) {
                     <EditWorkDialog work={work} />
                     <ManageAlertDialog
                       trigger={
-                        <Button
-                          size="sm"
-                          variant="surface"
-                          className="flex-1 rounded-lg hover:text-red-500"
+                        <button
+                          className={cn(
+                            buttonVariants({ variant: 'surface', size: 'sm' }),
+                            'flex-1 rounded-lg hover:text-red-500'
+                          )}
                         >
                           <Trash2 className="h-3.5 w-3.5" />
                           삭제
-                        </Button>
+                        </button>
                       }
                       icon={<Trash2 />}
                       iconContainerClassName="bg-red-100 text-red-500"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default async function Home({
           width={920}
           height={425}
           priority
-          className="pointer-events-none absolute top-0 left-1/2 -z-10 h-auto w-[60%] -translate-x-1/2"
+          className="pointer-events-none absolute top-0 left-1/2 -z-1 h-auto w-[60%] -translate-x-1/2"
         />
         <div className="mx-auto max-w-6xl px-3.5 py-20 text-center">
           {/* hero title, text */}

--- a/src/components/exhibition/manage/imageUploadBox.tsx
+++ b/src/components/exhibition/manage/imageUploadBox.tsx
@@ -62,6 +62,7 @@ export default function ImageUploadBox({
             src={preview}
             alt="작품 미리보기"
             fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
             className="object-cover"
           />
 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -17,7 +17,7 @@ export default async function Header() {
 
   return (
     <header className="h-16">
-      <div className="border-secondary/8 fixed top-0 z-60 h-16 w-full border-b bg-[#FAF7F2]/95 shadow-[0_2px_8px_rgba(44,40,38,0.06)] backdrop-blur">
+      <div className="border-secondary/8 fixed top-0 z-30 h-16 w-full border-b bg-[#FAF7F2]/95 shadow-[0_2px_8px_rgba(44,40,38,0.06)] backdrop-blur">
         <div className="mx-auto flex h-full max-w-6xl items-center justify-between px-3.5">
           <div className="flex items-center gap-4">
             <Link href="/" className="flex items-center gap-2">


### PR DESCRIPTION
## 📌 개요

모달 팝업 상단부의 z-index가 헤더보다 낮아 헤더에 가려져 상단부가 안보이는 현상으로 수정했습니다.

## 🔍 변경 사항

- 컴포넌트 전반적으로 z-index 확인 후 조정
- 모달 이미지 사이즈 css 추가
- 모달 버튼 충돌 에러 수정

## 🔗 관련 이슈 번호

- close #97 

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경 없음

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

모달 버튼 충돌 에러는 기능에 영향없이 버튼 태그만 변경하였습니다.
