### PR TITLE
[PR] 전시회 관람페이지 기능 수정/추가

### DIFF
--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -8,7 +8,7 @@ import Scene2 from '@/components/galleryExhibition/threejs/Scene';
 import { createClient } from '@/lib/supabase/client';
 import { User } from '@supabase/supabase-js';
 import { getExhibitionDetails } from '@/service/exhibitions';
-
+import { X } from 'lucide-react';
 export default function GalleryExhibitionPage() {
   const { id } = useParams<{ id: string }>();
   const [user, setUser] = useState<User | null>(null);
@@ -91,7 +91,7 @@ export default function GalleryExhibitionPage() {
                 👁️ 마우스로 시선 이동
               </p>
               <p className={'text-secondary/40 text-[14px]'}>
-                🖼️ 키보드 숫자키 1 - 좋아요 2 - 작품 다운로드
+                🖼️ 키보드 숫자키 1 - 좋아요 / 숫자키 2 - 작품 다운로드
               </p>
               <p className={'text-secondary/40 text-[14px]'}>
                 ESC로 마우스 조작 해제
@@ -118,9 +118,7 @@ export default function GalleryExhibitionPage() {
         </ModalWrapper>
       )}
 
-      <div
-        className={'absolute z-40 flex w-full items-start justify-between p-5'}
-      >
+      <div className={'absolute inset-0 z-40 flex w-full items-start p-5'}>
         <button
           onClick={(e) => {
             e.preventDefault();
@@ -140,27 +138,25 @@ export default function GalleryExhibitionPage() {
         </button>
         {!isMuted && (
           <div
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsMuted((s) => !s);
-            }}
-            className={'flex items-center gap-2'}
+            className={
+              'absolute bottom-0 left-1/2 flex -translate-x-1/2 items-center gap-2 p-5'
+            }
           >
-            <div
-              className={
-                'flex flex-col items-center rounded-lg bg-black/50 p-3 backdrop-blur-lg'
-              }
-            >
-              <p className={'text-white/80'}>숫자키 1</p>
-              <p className={'text-[14px] text-white/50'}>좋아요</p>
-            </div>
-            <div
-              className={
-                'flex flex-col items-center rounded-lg bg-black/50 p-3 backdrop-blur-lg'
-              }
-            >
-              <p className={'text-white/80'}>숫자키 2</p>
-              <p className={'text-[14px] text-white/50'}>다운로드</p>
+            <div className={'flex items-center justify-center gap-1'}>
+              <div
+                className={
+                  'flex items-center gap-3 rounded-lg bg-black/50 px-3 py-2 text-[14px] backdrop-blur-lg'
+                }
+              >
+                <p className={'text-white/80'}>숫자키 1 - 좋아요</p>
+                <p className={'text-white/80'}>숫자키 2 - 다운로드</p>
+              </div>
+              <button
+                onClick={() => setIsMuted(true)}
+                className={'rounded-full bg-black/50 p-1.5'}
+              >
+                <X size={20} className={'text-white/80'} />
+              </button>
             </div>
           </div>
         )}

--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -7,11 +7,16 @@ import { getArtworksByExhibitionId } from '@/service/artworks';
 import Scene2 from '@/components/galleryExhibition/threejs/Scene';
 import { createClient } from '@/lib/supabase/client';
 import { User } from '@supabase/supabase-js';
+import { getExhibitionDetails } from '@/service/exhibitions';
 
 export default function GalleryExhibitionPage() {
   const { id } = useParams<{ id: string }>();
   const [user, setUser] = useState<User | null>(null);
   const router = useRouter();
+  const [exhibitionDetails, setExhibitionDetails] = useState({
+    title: '',
+    host: '',
+  });
   const [galleryInit, setGalleryInit] = useState([]);
   const [isMuted, setIsMuted] = useState(false);
   const [start, setStart] = useState(false);
@@ -26,11 +31,13 @@ export default function GalleryExhibitionPage() {
       try {
         const supabase = createClient();
 
-        const [artworksRes, userRes] = await Promise.all([
+        const [artworksRes, userRes, exhibitionDetails] = await Promise.all([
           getArtworksByExhibitionId(id),
           supabase.auth.getUser(),
+          getExhibitionDetails(id),
         ]);
 
+        setExhibitionDetails(exhibitionDetails);
         setGalleryInit(artworksRes);
         setUser(userRes.data.user ?? null);
         setIsInitReady(true);
@@ -125,8 +132,10 @@ export default function GalleryExhibitionPage() {
         >
           <IoIosArrowBack className={'text-lg text-white/80'} />
           <div className={'flex flex-col'}>
-            <p className={'font-bold text-white/80'}>봄의 소리전</p>
-            <p className={'text-sm text-white/30'}>해피아트 미술학원</p>
+            <p className={'font-bold text-white/80'}>
+              {exhibitionDetails.title}
+            </p>
+            <p className={'text-sm text-white/30'}>{exhibitionDetails.host}</p>
           </div>
         </button>
         {!isMuted && (

--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -2,8 +2,6 @@
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { IoIosArrowBack } from 'react-icons/io';
-import { VscMute } from 'react-icons/vsc';
-import { AiOutlineSound } from 'react-icons/ai';
 import ModalWrapper from '@/components/galleryExhibition/threejs/ModalWrapper';
 import { getArtworksByExhibitionId } from '@/service/artworks';
 import Scene2 from '@/components/galleryExhibition/threejs/Scene';
@@ -131,21 +129,32 @@ export default function GalleryExhibitionPage() {
             <p className={'text-sm text-white/30'}>해피아트 미술학원</p>
           </div>
         </button>
-        <div
-          onClick={(e) => {
-            e.stopPropagation();
-            setIsMuted((s) => !s);
-          }}
-          className={
-            'flex items-center gap-2 rounded-lg bg-black/50 p-3 backdrop-blur-lg'
-          }
-        >
-          {isMuted ? (
-            <VscMute className={'text-xl text-white/80'} />
-          ) : (
-            <AiOutlineSound className={'text-xl text-white/80'} />
-          )}
-        </div>
+        {!isMuted && (
+          <div
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsMuted((s) => !s);
+            }}
+            className={'flex items-center gap-2'}
+          >
+            <div
+              className={
+                'flex flex-col items-center rounded-lg bg-black/50 p-3 backdrop-blur-lg'
+              }
+            >
+              <p className={'text-white/80'}>숫자키 1</p>
+              <p className={'text-[14px] text-white/50'}>좋아요</p>
+            </div>
+            <div
+              className={
+                'flex flex-col items-center rounded-lg bg-black/50 p-3 backdrop-blur-lg'
+              }
+            >
+              <p className={'text-white/80'}>숫자키 2</p>
+              <p className={'text-[14px] text-white/50'}>다운로드</p>
+            </div>
+          </div>
+        )}
       </div>
       <div
         className={`h-screen w-screen bg-white ${!start ? 'pointer-events-none opacity-0' : 'pointer-events-auto opacity-100'} `}

--- a/src/components/galleryExhibition/threejs/InnerWall.tsx
+++ b/src/components/galleryExhibition/threejs/InnerWall.tsx
@@ -8,11 +8,13 @@ export default function InnerWalls({
   init,
   walls,
   paintingRefs,
+  htmlRefs,
 }: {
   paintingTextures: Texture[];
   init: GalleryUIArtworkProps[];
   walls: WAllType[];
   paintingRefs: React.RefObject<(Group | null)[]>;
+  htmlRefs: React.RefObject<(HTMLDivElement | null)[]>;
 }) {
   return (
     <>
@@ -31,6 +33,7 @@ export default function InnerWalls({
                 paintingRef={(el) => {
                   paintingRefs.current[i] = el;
                 }}
+                htmlRef={(el) => (htmlRefs.current[i] = el)}
                 details={paintingDetails}
                 weight={w}
                 height={h}

--- a/src/components/galleryExhibition/threejs/InnerWall.tsx
+++ b/src/components/galleryExhibition/threejs/InnerWall.tsx
@@ -18,23 +18,24 @@ export default function InnerWalls({
     <>
       {walls.map((wall, i) => {
         const [w, h, d] = wall.boxSize;
-
+        const paintingDetails = init[i];
         return (
           <group key={i} position={wall.pos} rotation={wall.rot}>
             <mesh>
               <boxGeometry args={[w, h, d]} />
               <meshStandardMaterial color="#E6E0D6" />
             </mesh>
-
-            <Painting
-              img={paintingTextures[i]}
-              paintingRef={(el) => {
-                paintingRefs.current[i] = el;
-              }}
-              details={init[i]}
-              weight={w}
-              height={h}
-            />
+            {paintingDetails && (
+              <Painting
+                img={paintingTextures[i]}
+                paintingRef={(el) => {
+                  paintingRefs.current[i] = el;
+                }}
+                details={paintingDetails}
+                weight={w}
+                height={h}
+              />
+            )}
           </group>
         );
       })}

--- a/src/components/galleryExhibition/threejs/Painting.tsx
+++ b/src/components/galleryExhibition/threejs/Painting.tsx
@@ -10,12 +10,14 @@ export default function Painting({
   weight: w,
   height: h,
   paintingRef,
+  htmlRef,
 }: {
   img: Texture;
   details: GalleryUIArtworkProps;
   weight: number;
   height: number;
   paintingRef?: (mesh: Group | null) => void;
+  htmlRef?: (el: HTMLDivElement | null) => void;
 }) {
   const [imgW, imgH] = checkImgSize(img, w, h, 0.4);
 
@@ -23,28 +25,33 @@ export default function Painting({
   return (
     <group ref={paintingRef} position={[0, 0, 0.3]}>
       <mesh receiveShadow position={[0, 0, 0.03]}>
-        <planeGeometry args={[imgW * 0.95, imgH * 0.9]} />
-        <meshBasicMaterial map={img} />
+        <planeGeometry args={[imgW * 0.95, imgH * 0.95]} />
+        <meshStandardMaterial map={img} />
       </mesh>
       <mesh castShadow receiveShadow>
         <boxGeometry args={[imgW, imgH, 0.05]} />
-        <meshStandardMaterial color={'black'} />
+        <meshBasicMaterial color={'black'} />
       </mesh>
       <Html
+        ref={htmlRef}
         transform
         position={[0, -h / 2 + 0.8, 0.13]}
         distanceFactor={2}
         center
         occlude
         style={{
+          opacity: 0,
+          pointerEvents: 'none',
           transition: 'opacity 0.4s ease, transform 0.4s ease',
           willChange: 'opacity, transform',
         }}
       >
-        <div className={'gap flex flex-col gap-1 font-bold text-white'}>
-          <h1 className={'text-[45px]'}>{details?.title}</h1>
-          <h1 className={'text-[25px]'}>{details?.artist_name}</h1>
-          <p className={'text-[20px] text-wrap text-gray-200'}>
+        <div
+          className={`gap flex max-w-100 min-w-80 flex-col gap-1 font-bold text-white`}
+        >
+          <h1 className={'text-[40px]'}>{details?.title}</h1>
+          <h1 className={'text-[20px]'}>{details?.artist_name}</h1>
+          <p className={'text-[15px] text-wrap text-gray-200'}>
             {details?.description}
           </p>
           <div className={'mt-1 flex justify-end gap-2 text-gray-200'}>

--- a/src/components/galleryExhibition/threejs/Player.tsx
+++ b/src/components/galleryExhibition/threejs/Player.tsx
@@ -7,10 +7,12 @@ export default function Player({
   size = 15,
   speed = 5,
   innerWalls,
+  startPos,
 }: {
   size?: number;
   speed: number;
   innerWalls: WAllType[];
+  startPos: { x: number; y: number; z: number };
 }) {
   const velocity = useRef(new THREE.Vector3());
   const direction = useRef(new THREE.Vector3());
@@ -27,15 +29,19 @@ export default function Player({
 
   const localPos = useRef(new THREE.Vector3());
 
+  const initialized = useRef(false);
+
   const colliders = useMemo(() => {
     return innerWalls.map((wall) => {
       const pos = new THREE.Vector3(...wall.pos);
       const rot = new THREE.Euler(...(wall.rot ?? [0, 0, 0]));
+
       const mat = new THREE.Matrix4().compose(
         pos,
         new THREE.Quaternion().setFromEuler(rot),
         new THREE.Vector3(1, 1, 1)
       );
+
       return {
         inv: mat.clone().invert(),
         halfX: wall.boxSize[0] / 2,
@@ -43,6 +49,7 @@ export default function Player({
       };
     });
   }, [innerWalls]);
+
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       const key = e.code
@@ -72,7 +79,15 @@ export default function Player({
       window.removeEventListener('keyup', up);
     };
   }, []);
+
   useFrame((state, delta) => {
+    const camera = state.camera;
+
+    if (!initialized.current && startPos) {
+      camera.position.set(startPos.x, startPos.y, startPos.z);
+      initialized.current = true;
+    }
+
     direction.current.set(0, 0, 0);
 
     if (keys.current.w) direction.current.z -= 1;
@@ -82,8 +97,6 @@ export default function Player({
 
     velocity.current.x = direction.current.x * speed * delta;
     velocity.current.z = direction.current.z * speed * delta;
-
-    const camera = state.camera;
 
     camera.getWorldDirection(forward.current);
     forward.current.y = 0;
@@ -109,7 +122,6 @@ export default function Player({
     const newPos = new THREE.Vector3(newX, size / 30, newZ);
 
     let blocked = false;
-
     const pad = 0.3;
 
     for (const collider of colliders) {
@@ -129,5 +141,6 @@ export default function Player({
       camera.position.copy(newPos);
     }
   });
-  return <>{/*<pointLight position={[0,2,0]} intensity={10} />*/}</>;
+
+  return null;
 }

--- a/src/components/galleryExhibition/threejs/Player.tsx
+++ b/src/components/galleryExhibition/threejs/Player.tsx
@@ -119,7 +119,7 @@ export default function Player({
       right.current.z * velocity.current.x -
       forward.current.z * velocity.current.z;
 
-    const newPos = new THREE.Vector3(newX, size / 30, newZ);
+    const newPos = new THREE.Vector3(newX, startPos.y, newZ);
 
     let blocked = false;
     const pad = 0.3;

--- a/src/components/galleryExhibition/threejs/Player.tsx
+++ b/src/components/galleryExhibition/threejs/Player.tsx
@@ -4,7 +4,6 @@ import * as THREE from 'three';
 import { WAllType } from '../../../types/gallery';
 
 export default function Player({
-  size = 15,
   speed = 5,
   innerWalls,
   startPos,

--- a/src/components/galleryExhibition/threejs/Room.tsx
+++ b/src/components/galleryExhibition/threejs/Room.tsx
@@ -29,8 +29,7 @@ export default function Room({
   user: User | null;
 }) {
   const [artworks, setArtworks] = useState(init);
-  const [loading, setLoading] = useState(false);
-
+  const loadingRef = useRef(false);
   const urls = useMemo(() => artworks.map((x) => x.image_url), [artworks]);
   const paintingTextures = useTexture(urls);
 
@@ -111,12 +110,12 @@ export default function Room({
   useEffect(() => {
     const postLikes = async () => {
       const painting = closestPaintingRef.current;
-      if (!painting || loading) return;
+      if (!painting || loadingRef.current) return;
 
       const closestId = painting.id;
 
       let prevArtworks: GalleryUIArtworkProps[];
-
+      loadingRef.current = true;
       setArtworks((prev) => {
         prevArtworks = [...prev];
 
@@ -131,15 +130,13 @@ export default function Room({
         );
       });
 
-      setLoading(true);
-
       try {
         await likesToggle(exhibitionId, closestId);
       } catch (e) {
         console.log(e);
         setArtworks(prevArtworks!);
       } finally {
-        setLoading(false);
+        loadingRef.current = false;
       }
     };
 
@@ -162,7 +159,7 @@ export default function Room({
     return () => {
       window.removeEventListener('keydown', handler);
     };
-  }, [loading, exhibitionId, user]);
+  }, [exhibitionId, user]);
 
   return (
     <>

--- a/src/components/galleryExhibition/threejs/Room.tsx
+++ b/src/components/galleryExhibition/threejs/Room.tsx
@@ -30,19 +30,83 @@ export default function Room({
 }) {
   const [artworks, setArtworks] = useState(init);
   const [loading, setLoading] = useState(false);
-  const urls = useMemo(() => artworks.map((x) => x.image_url), [artworks]);
 
+  const urls = useMemo(() => artworks.map((x) => x.image_url), [artworks]);
   const paintingTextures = useTexture(urls);
+
   const paintingRefs = useRef<(Group | null)[]>([]);
-  const tempCurrentForward = useRef(new Vector3());
+  const htmlRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const tempForward = useRef(new Vector3());
+  const tempPos = useRef(new Vector3());
+  const tempDir = useRef(new Vector3());
 
   const prevPos = useRef(new Vector3());
   const prevDir = useRef(new Vector3());
 
-  const tempPos = useRef(new Vector3());
-  const tempDir = useRef(new Vector3());
+  const prevIndexRef = useRef<number>(-1);
 
   const closestPaintingRef = useRef<GalleryUIArtworkProps | null>(null);
+
+  useFrame(({ camera }) => {
+    camera.getWorldDirection(tempForward.current);
+    const forward = tempForward.current;
+
+    const moved = prevPos.current.distanceToSquared(camera.position) > 0.01;
+    const rotated = 1 - prevDir.current.dot(forward) > 0.01;
+
+    if (!moved && !rotated) return;
+
+    let bestIndex = -1;
+    let bestScore = -Infinity;
+
+    for (let i = 0; i < artworks.length; i++) {
+      const mesh = paintingRefs.current[i];
+      if (!mesh) continue;
+
+      mesh.getWorldPosition(tempPos.current);
+
+      tempDir.current.copy(tempPos.current).sub(camera.position);
+
+      const distanceSq = tempDir.current.lengthSq();
+
+      tempDir.current.normalize();
+
+      const fovDot = forward.dot(tempDir.current);
+
+      if (fovDot < 0.5 || distanceSq > 25) continue;
+
+      const score = fovDot * 20 - Math.sqrt(distanceSq) * 10;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    if (prevIndexRef.current !== bestIndex) {
+      if (prevIndexRef.current !== -1) {
+        const prevHtml = htmlRefs.current[prevIndexRef.current];
+        if (prevHtml) {
+          prevHtml.style.opacity = '0';
+        }
+      }
+
+      if (bestIndex !== -1) {
+        const nextHtml = htmlRefs.current[bestIndex];
+        if (nextHtml) {
+          nextHtml.style.opacity = '1';
+        }
+      }
+
+      prevIndexRef.current = bestIndex;
+    }
+
+    closestPaintingRef.current = bestIndex !== -1 ? artworks[bestIndex] : null;
+
+    prevPos.current.copy(camera.position);
+    prevDir.current.copy(forward);
+  });
 
   useEffect(() => {
     const postLikes = async () => {
@@ -51,9 +115,11 @@ export default function Room({
 
       const closestId = painting.id;
 
-      let prevArtworks;
+      let prevArtworks: GalleryUIArtworkProps[];
+
       setArtworks((prev) => {
         prevArtworks = [...prev];
+
         return prev.map((x) =>
           x.id === closestId
             ? {
@@ -64,19 +130,21 @@ export default function Room({
             : x
         );
       });
+
       setLoading(true);
+
       try {
         await likesToggle(exhibitionId, closestId);
       } catch (e) {
         console.log(e);
-        setArtworks(prevArtworks || []);
+        setArtworks(prevArtworks!);
       } finally {
         setLoading(false);
       }
     };
+
     const handler = (e: KeyboardEvent) => {
       const painting = closestPaintingRef.current;
-
       if (!painting) return;
 
       if (e.key === '1') {
@@ -96,56 +164,6 @@ export default function Room({
     };
   }, [loading, exhibitionId, user]);
 
-  useFrame(({ camera }) => {
-    camera.getWorldDirection(tempCurrentForward.current);
-
-    const forward = tempCurrentForward.current;
-
-    const moved = prevPos.current.distanceTo(camera.position) > 0.1;
-
-    const rotated = 1 - prevDir.current.dot(forward) > 0.01;
-
-    if (!moved && !rotated) return;
-
-    let bestIndex = -1;
-    let bestScore = -Infinity;
-
-    for (let i = 0; i < innerWalls.length; i++) {
-      const mesh = paintingRefs.current[i];
-
-      if (!mesh) continue;
-
-      mesh.getWorldPosition(tempPos.current);
-
-      tempDir.current.copy(tempPos.current).sub(camera.position);
-
-      const distance = tempDir.current.length();
-
-      tempDir.current.normalize();
-
-      const fovDot = forward.dot(tempDir.current);
-
-      //소규모니까 그냥 전부 보이게
-      // const paintingVisible = fovDot > 0.7;
-      // mesh.visible = paintingVisible;
-
-      const closestPaintingVisible = fovDot > 0.5 && distance < 5;
-
-      if (closestPaintingVisible) {
-        const score = fovDot * 20 - distance * 10;
-
-        if (score > bestScore) {
-          bestScore = score;
-          bestIndex = i;
-        }
-      }
-    }
-
-    closestPaintingRef.current = bestIndex !== -1 ? artworks[bestIndex] : null;
-
-    prevPos.current.copy(camera.position);
-    prevDir.current.copy(forward);
-  });
   return (
     <>
       <Floor size={size} />
@@ -157,6 +175,7 @@ export default function Room({
         init={artworks}
         paintingTextures={paintingTextures}
         paintingRefs={paintingRefs}
+        htmlRefs={htmlRefs}
       />
 
       <Ceiling size={size} height={height} />

--- a/src/components/galleryExhibition/threejs/Scene.tsx
+++ b/src/components/galleryExhibition/threejs/Scene.tsx
@@ -21,7 +21,10 @@ export default function Scene2({
   // console.log(init)
   const size = 21;
   const height = size * 0.3;
-  const innerWalls = useMemo(() => generateGalleryWalls(size), [size]);
+  const { innerWalls, startPosition } = useMemo(
+    () => generateGalleryWalls(size),
+    [size]
+  );
   const walls = useMemo(() => createWalls(size, height), [size, height]);
 
   const { active, loaded, total } = useProgress();
@@ -43,7 +46,12 @@ export default function Scene2({
         />
         <ambientLight intensity={1} />
 
-        <Player innerWalls={innerWalls} size={size} speed={3} />
+        <Player
+          startPos={startPosition}
+          innerWalls={innerWalls}
+          size={size}
+          speed={3}
+        />
         <PointerLockControls />
       </Canvas>
     </>

--- a/src/components/galleryExhibition/threejs/Scene.tsx
+++ b/src/components/galleryExhibition/threejs/Scene.tsx
@@ -46,12 +46,7 @@ export default function Scene2({
         />
         <ambientLight intensity={1} />
 
-        <Player
-          startPos={startPosition}
-          innerWalls={innerWalls}
-          size={size}
-          speed={3}
-        />
+        <Player startPos={startPosition} innerWalls={innerWalls} speed={3} />
         <PointerLockControls />
       </Canvas>
     </>

--- a/src/lib/gallery/createWalls.ts
+++ b/src/lib/gallery/createWalls.ts
@@ -5,6 +5,11 @@ export function generateGalleryWalls(roomSize: number) {
   const cellSize = roomSize / size;
   const half = roomSize / 2;
 
+  const startPosition = {
+    x: -half + cellSize / 2,
+    y: 1.6,
+    z: -half + cellSize / 2,
+  };
   // 1. grid 생성
   const grid: Cell[][] = [];
 
@@ -149,7 +154,10 @@ export function generateGalleryWalls(roomSize: number) {
     }
   }
 
-  return walls;
+  return {
+    innerWalls: walls,
+    startPosition,
+  };
 }
 
 export const createWalls = (

--- a/src/service/exhibitions.ts
+++ b/src/service/exhibitions.ts
@@ -19,7 +19,9 @@ export const getExhibitionDetails = async (id: string) => {
     const error = await res.json();
     throw new Error(error.message);
   }
-  const { data:{title,host} } = await res.json();
+  const {
+    data: { title, host },
+  } = await res.json();
 
   return { title, host };
 };

--- a/src/service/exhibitions.ts
+++ b/src/service/exhibitions.ts
@@ -19,10 +19,9 @@ export const getExhibitionDetails = async (id: string) => {
     const error = await res.json();
     throw new Error(error.message);
   }
-  const {
-    data: { title, host },
-  } = await res.json();
-
+  const { data } = await res.json();
+  const title = data?.title || '';
+  const host = data?.host || '';
   return { title, host };
 };
 export const toggleExhibitionLike = async (

--- a/src/service/exhibitions.ts
+++ b/src/service/exhibitions.ts
@@ -12,7 +12,17 @@ export const postNewExhibition = async (formDate: FormData) => {
 
   return createdId;
 };
+export const getExhibitionDetails = async (id: string) => {
+  const res = await fetch(`/api/exhibitions/${id}`);
 
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message);
+  }
+  const { data:{title,host} } = await res.json();
+
+  return { title, host };
+};
 export const toggleExhibitionLike = async (
   exhibitionId: string,
   nextLiked: boolean


### PR DESCRIPTION
## 📌 개요

> 전시회 관람페이지 유저 상호작용 개선

## 🔍 변경 사항

> 주요 변경 사항을 설명해주세요.

- 소리 버튼 제거
- 처음 사용자 스폰되는 위치를 작품 가까이로 조정
- 작품근처로 이동시 작품 설명 표시
- 관람 페이지 우측 상단 유저 상호작용 도움말 표시


## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #94 

## 📸 스크린샷 (UI 변경 시 필수)
<img width="1911" height="948" alt="스크린샷 2026-05-14 오후 2 58 10" src="https://github.com/user-attachments/assets/498c44fa-f50f-4a87-80f5-c416462494db" />

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
