### PR TITLE
[PR] not-found 페이지 개발

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -7,7 +7,7 @@ export const NotFound = () => {
       <div className="flex h-screen w-full items-center justify-center bg-[#faf7f2]">
         <div className="flex flex-col items-center">
           {/* 팔레트 아이콘 */}
-          <div className="bg- flex h-24 w-24 items-center justify-center rounded-[24px] bg-linear-to-br from-[#F4B942] to-[#FF7B6B]">
+          <div className="flex h-24 w-24 items-center justify-center rounded-[24px] bg-linear-to-br from-[#F4B942] to-[#FF7B6B]">
             <Palette size={48} color="white" strokeWidth={3} />
           </div>
           {/* 하단 텍스트 */}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,36 @@
+import { Palette } from 'lucide-react';
+import Link from 'next/link';
+
+export const NotFound = () => {
+  return (
+    <>
+      <div className="flex h-screen w-full items-center justify-center bg-[#faf7f2]">
+        <div className="flex flex-col items-center">
+          {/* 팔레트 아이콘 */}
+          <div className="bg- flex h-24 w-24 items-center justify-center rounded-[24px] bg-linear-to-br from-[#F4B942] to-[#FF7B6B]">
+            <Palette size={48} color="white" strokeWidth={3} />
+          </div>
+          {/* 하단 텍스트 */}
+          <h1 className="text-primary mt-6 text-[80px] leading-20 font-extrabold">
+            404
+          </h1>
+          <h3 className="mt-1.5 text-2xl leading-9 font-semibold">
+            페이지를 찾을 수 없어요
+          </h3>
+          <p className="mt-3.25 text-[14px] leading-5 font-normal text-[rgba(44,40,38,0.50)]">
+            요청하신 페이지가 존재하지 않거나 이동되었습니다.
+          </p>
+          <Link
+            href={'/'}
+            className="bg-primary mt-7.5 rounded-[16px] pt-3.25 pr-[20.75px] pb-3.75 pl-5 shadow-md hover:opacity-70"
+          >
+            <span className="text-[16px] leading-6 font-semibold text-white">
+              메인으로 돌아가기
+            </span>
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+};
+export default NotFound;


### PR DESCRIPTION
## 📌 개요

권한이 없는 혹은 존재하지 않는 페이지 접근 시 보여줄 404 Not Found 페이지를 개발했습니다.
기존에는 Next.js 기본 404 화면이 노출되었으나, 서비스 디자인에 맞는 커스텀 페이지로 교체합니다.

## 🔍 변경 사항

- `src/app/not-found.tsx` 신규 생성 — Next.js App Router의 `not-found` 컨벤션 활용
- "메인으로 돌아가기" 링크 버튼으로 홈(`/`) 이동 제공

## 🔗 관련 이슈 번호

- close #103

## 📸 스크린샷 (UI 변경 시 필수)

<img width="500px" alt="스크린샷 2026-05-15 오전 11 05 54" src="https://github.com/user-attachments/assets/80ba4048-e44f-4399-ab8e-f550bc14463a" />

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항