### PR TITLE
[PR] 메인 페이지 전시회 리스트 컴포넌트 분리 후 비동기 렌더링 적용

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import { ExhibitionListContent } from '@/components/home/exhibitionListContent';
+import ExhibitionListSkeleton from '@/components/home/exhibitionListSkeleton';
 import SearchForm from '@/components/home/searchForm';
 import { getAuthContext } from '@/lib/auth/getAuthContext';
 import { ExhibitionSort } from '@/types/exhibitionList';
 import { Sparkles } from 'lucide-react';
 import Image from 'next/image';
 import { redirect } from 'next/navigation';
+import { Suspense } from 'react';
 
 export default async function Home({
   searchParams,
@@ -64,14 +66,18 @@ export default async function Home({
         </div>
       </section>
       {/* // hero section */}
-      <ExhibitionListContent
-        sort={sort}
-        search={search}
-        page={page}
-        userId={user?.id}
-        isTeacher={isTeacher}
-        isLoggedIn={!!user}
-      />
+      <div className="mx-auto max-w-6xl px-3.5 pb-20">
+        <Suspense fallback={<ExhibitionListSkeleton />}>
+          <ExhibitionListContent
+            sort={sort}
+            search={search}
+            page={page}
+            userId={user?.id}
+            isTeacher={isTeacher}
+            isLoggedIn={!!user}
+          />
+        </Suspense>
+      </div>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import ExhibitionList from '@/components/home/exhibitionList';
+import { ExhibitionListContent } from '@/components/home/exhibitionListContent';
 import ListPagination from '@/components/home/listPagination';
 import SearchForm from '@/components/home/searchForm';
 import { getAuthContext } from '@/lib/auth/getAuthContext';
@@ -26,15 +27,6 @@ export default async function Home({
   const sort = (
     sortParam === 'mine' && !isTeacher ? 'latest' : (sortParam ?? 'latest')
   ) as ExhibitionSort;
-
-  const { data: exhibitions, pagination } = await fetchExhibitions({
-    sort,
-    search,
-    page,
-    userId: user?.id,
-  });
-
-  if (page > 1 && exhibitions.length === 0) return notFound();
 
   return (
     <main className="bg-[#FAF7F2]">
@@ -75,20 +67,14 @@ export default async function Home({
         </div>
       </section>
       {/* // hero section */}
-      <div className="mx-auto max-w-6xl px-3.5 pb-20">
-        <ExhibitionList
-          exhibitions={exhibitions}
-          sort={sort}
-          isTeacher={isTeacher}
-          isLoggedIn={!!user}
-        />
-        <ListPagination
-          currentPage={pagination.page}
-          totalCount={pagination.totalCount}
-          sort={sort}
-          search={search}
-        />
-      </div>
+      <ExhibitionListContent
+        sort={sort}
+        search={search}
+        page={page}
+        userId={user?.id}
+        isTeacher={isTeacher}
+        isLoggedIn={!!user}
+      />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,10 @@
-import ExhibitionList from '@/components/home/exhibitionList';
 import { ExhibitionListContent } from '@/components/home/exhibitionListContent';
-import ListPagination from '@/components/home/listPagination';
 import SearchForm from '@/components/home/searchForm';
 import { getAuthContext } from '@/lib/auth/getAuthContext';
-import { fetchExhibitions } from '@/lib/exhibition/queries';
 import { ExhibitionSort } from '@/types/exhibitionList';
 import { Sparkles } from 'lucide-react';
 import Image from 'next/image';
-import { notFound, redirect } from 'next/navigation';
+import { redirect } from 'next/navigation';
 
 export default async function Home({
   searchParams,

--- a/src/components/home/exhibitionListContent.tsx
+++ b/src/components/home/exhibitionListContent.tsx
@@ -31,20 +31,18 @@ export async function ExhibitionListContent({
   if (page > 1 && exhibitions.length === 0) return notFound();
   return (
     <>
-      <div className="mx-auto max-w-6xl px-3.5 pb-20">
-        <ExhibitionList
-          exhibitions={exhibitions}
-          sort={sort}
-          isTeacher={isTeacher}
-          isLoggedIn={isLoggedIn}
-        />
-        <ListPagination
-          currentPage={pagination.page}
-          totalCount={pagination.totalCount}
-          sort={sort}
-          search={search}
-        />
-      </div>
+      <ExhibitionList
+        exhibitions={exhibitions}
+        sort={sort}
+        isTeacher={isTeacher}
+        isLoggedIn={isLoggedIn}
+      />
+      <ListPagination
+        currentPage={pagination.page}
+        totalCount={pagination.totalCount}
+        sort={sort}
+        search={search}
+      />
     </>
   );
 }

--- a/src/components/home/exhibitionListContent.tsx
+++ b/src/components/home/exhibitionListContent.tsx
@@ -1,0 +1,50 @@
+import { fetchExhibitions } from '@/lib/exhibition/queries';
+import ExhibitionList from './exhibitionList';
+import ListPagination from './listPagination';
+import { ExhibitionSort } from '@/types/exhibitionList';
+import { notFound } from 'next/navigation';
+
+interface ExhibitionListContentProps {
+  sort: ExhibitionSort;
+  search?: string;
+  page: number;
+  userId?: string;
+  isTeacher: boolean;
+  isLoggedIn: boolean;
+}
+
+export async function ExhibitionListContent({
+  sort,
+  search,
+  page,
+  userId,
+  isTeacher,
+  isLoggedIn,
+}: ExhibitionListContentProps) {
+  const { data: exhibitions, pagination } = await fetchExhibitions({
+    sort,
+    search,
+    page,
+    userId,
+  });
+
+  if (page > 1 && exhibitions.length === 0) return notFound();
+  return (
+    <>
+      <div className="mx-auto max-w-6xl px-3.5 pb-20">
+        <ExhibitionList
+          exhibitions={exhibitions}
+          sort={sort}
+          isTeacher={isTeacher}
+          isLoggedIn={isLoggedIn}
+        />
+        <ListPagination
+          currentPage={pagination.page}
+          totalCount={pagination.totalCount}
+          sort={sort}
+          search={search}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/home/exhibitionListSkeleton.tsx
+++ b/src/components/home/exhibitionListSkeleton.tsx
@@ -1,0 +1,39 @@
+export default function ExhibitionListSkeleton() {
+  const cardCount = 8;
+  const filterCount = 6;
+  return (
+    <>
+      <section className="space-y-6" aria-busy="true">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap gap-2">
+            {Array.from({ length: filterCount }).map((_, i) => (
+              <div
+                key={`filter-skeleton:${i + 1}`}
+                className="h-9 w-20 animate-pulse rounded-full bg-[#EDE6DA]"
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: cardCount }, (_, index) => (
+            <div
+              key={index}
+              className="overflow-hidden rounded-2xl bg-white shadow-[0_2px_8px_rgba(44,40,38,0.06)]"
+            >
+              <div className="aspect-4/3 animate-pulse bg-[#EFE4D3]" />
+              <div className="space-y-3 p-4">
+                <div className="h-5 w-4/5 animate-pulse rounded bg-[#E7D8C4]" />
+                <div className="h-4 w-1/2 animate-pulse rounded bg-[#F2E9DC]" />
+                <div className="flex items-center justify-between pt-2">
+                  <div className="h-3 w-24 animate-pulse rounded bg-[#E7D8C4]" />
+                  <div className="h-3 w-10 animate-pulse rounded bg-[#F2E9DC]" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
## 📌 개요

메인 페이지에서 전시회 리스트 조회가 완료된 이후 전체 페이지가 렌더링되던 구조를 개선했습니다.

전시회 리스트 영역을 별도 서버 컴포넌트로 분리하고 `Suspense`를 적용해, 메인 페이지의 상단 콘텐츠가 먼저 렌더링될 수 있도록 변경했습니다. 리스트 데이터 로딩 중에는 스켈레톤 UI를 표시합니다.

## 🔍 변경 사항

- 메인 페이지의 전시회 리스트 데이터 패칭 로직을 `ExhibitionListContent` 컴포넌트로 분리
- `Suspense` fallback으로 전시회 리스트 스켈레톤 UI 추가
- 데이터 로딩 중 필터 영역과 카드 그리드 형태의 스켈레톤 표시

## 🔗 관련 이슈 번호

- close #109

## 📸 스크린샷 (UI 변경 시 필수)

<img width="3282" height="1888" alt="스크린샷 2026-05-15 오후 1 19 44" src="https://github.com/user-attachments/assets/37dc1c17-06b0-442b-961f-0c7c9c17f7a1" />

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

메인 페이지 렌더링 시간이 평균 1.75s ->  1.07s 로 39% 단축되었습니다.