### PR TITLE
[PR] 선생님 마이페이지 - 내가 운영하는 전시회 필터탭 추가

### DIFF
--- a/src/components/myPage/ExhibitionList.tsx
+++ b/src/components/myPage/ExhibitionList.tsx
@@ -1,13 +1,33 @@
+'use client';
+
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { Calendar } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import type { Exhibition } from '@/types/myPage';
+
+type Filter = 'all' | 'active' | 'upcoming' | 'ended';
+
+const FILTERS: { label: string; value: Filter }[] = [
+  { label: '전체', value: 'all' },
+  { label: '진행중', value: 'active' },
+  { label: '예정됨', value: 'upcoming' },
+  { label: '종료', value: 'ended' },
+];
 
 interface ExhibitionListProps {
   exhibitions: Exhibition[];
 }
 
 export default function ExhibitionList({ exhibitions }: ExhibitionListProps) {
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const filtered =
+    filter === 'all'
+      ? exhibitions
+      : exhibitions.filter((ex) => ex.status === filter);
+
   return (
     <section className="overflow-hidden rounded-[24px] border border-[#e8e1d7] bg-white shadow-[0_2px_8px_rgba(64,48,33,0.03)]">
       <div className="flex items-center justify-between px-7 pt-6 pb-4">
@@ -30,76 +50,93 @@ export default function ExhibitionList({ exhibitions }: ExhibitionListProps) {
             내가 운영하는 전시회
           </span>
         </div>
-        <Link
-          href="/exhibitions/create"
-          className="text-[12px] font-semibold text-[#e2ba50]"
-        >
-          + 새 전시회
-        </Link>
+
+        <div className="flex items-center gap-1">
+          {FILTERS.map(({ label, value }) => (
+            <button
+              key={value}
+              onClick={() => setFilter(value)}
+              className={cn(
+                'rounded-full px-4 py-2 text-sm font-medium transition-colors',
+                filter === value
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-white text-secondary/60 hover:bg-primary/10 hover:text-secondary'
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <ul className="px-5 pb-5">
-        {exhibitions.map((ex, idx) => (
-          <li key={ex.id}>
-            <Link
-              href={`/exhibitions/${ex.id}`}
-              className={`flex items-center gap-4 rounded-[18px] px-3 py-3 transition-colors hover:bg-[#faf7f1] ${
-                idx > 0 ? 'mt-1' : ''
-              }`}
-            >
-              <Image
-                src={ex.thumbnail || '/images/default_thumb.jpg'}
-                alt=""
-                width={44}
-                height={44}
-                className="shrink-0 rounded-[14px] object-cover"
-              />
-
-              <div className="min-w-0 flex-1">
-                <p className="mb-1 text-[14px] font-semibold text-[#2b2724]">
-                  {ex.title}
-                </p>
-                {ex.status === 'upcoming' ? (
-                  <p className="flex items-center gap-1 text-[12px] text-[#e2a93a]">
-                    <Calendar size={11} />
-                    {ex.start_date}부터 관람 가능
-                  </p>
-                ) : (
-                  <p className="text-[12px] text-[#9b948c]">
-                    {ex.artworkCount}점 ·{' '}
-                    {ex.status === 'active' ? '진행중' : '종료'}
-                  </p>
-                )}
-              </div>
-
-              <div className="flex items-center gap-3">
-                <span
-                  className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
-                    ex.status === 'active'
-                      ? 'bg-[#ecfaf2] text-[#43b77a]'
-                      : ex.status === 'upcoming'
-                        ? 'bg-[#fff4d9] text-[#d5981f]'
-                        : 'bg-[#f4f3f1] text-[#bbb3a8]'
-                  }`}
-                >
-                  {ex.status === 'active'
-                    ? '진행중'
-                    : ex.status === 'upcoming'
-                      ? '예정됨'
-                      : '종료'}
-                </span>
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M6 4l4 4-4 4"
-                    stroke="#c3bcb2"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </div>
-            </Link>
+        {filtered.length === 0 ? (
+          <li className="px-3 py-6 text-center text-[13px] text-[#c3bcb2]">
+            해당되는 전시회가 없습니다.
           </li>
-        ))}
+        ) : (
+          filtered.map((ex, idx) => (
+            <li key={ex.id}>
+              <Link
+                href={`/exhibitions/${ex.id}`}
+                className={`flex items-center gap-4 rounded-[18px] px-3 py-3 transition-colors hover:bg-[#faf7f1] ${
+                  idx > 0 ? 'mt-1' : ''
+                }`}
+              >
+                <Image
+                  src={ex.thumbnail || '/images/default_thumb.jpg'}
+                  alt=""
+                  width={44}
+                  height={44}
+                  className="shrink-0 rounded-[14px] object-cover"
+                />
+
+                <div className="min-w-0 flex-1">
+                  <p className="mb-1 text-[14px] font-semibold text-[#2b2724]">
+                    {ex.title}
+                  </p>
+                  {ex.status === 'upcoming' ? (
+                    <p className="flex items-center gap-1 text-[12px] text-[#e2a93a]">
+                      <Calendar size={11} />
+                      {ex.start_date}부터 관람 가능
+                    </p>
+                  ) : (
+                    <p className="text-[12px] text-[#9b948c]">
+                      {ex.artworkCount}점 ·{' '}
+                      {ex.status === 'active' ? '진행중' : '종료'}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
+                      ex.status === 'active'
+                        ? 'bg-[#ecfaf2] text-[#43b77a]'
+                        : ex.status === 'upcoming'
+                          ? 'bg-[#fff4d9] text-[#d5981f]'
+                          : 'bg-[#f4f3f1] text-[#bbb3a8]'
+                    }`}
+                  >
+                    {ex.status === 'active'
+                      ? '진행중'
+                      : ex.status === 'upcoming'
+                        ? '예정됨'
+                        : '종료'}
+                  </span>
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                    <path
+                      d="M6 4l4 4-4 4"
+                      stroke="#c3bcb2"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </div>
+              </Link>
+            </li>
+          ))
+        )}
       </ul>
     </section>
   );

--- a/src/components/myPage/ExhibitionList.tsx
+++ b/src/components/myPage/ExhibitionList.tsx
@@ -60,7 +60,7 @@ export default function ExhibitionList({ exhibitions }: ExhibitionListProps) {
                 'rounded-full px-4 py-2 text-sm font-medium transition-colors',
                 filter === value
                   ? 'bg-primary text-primary-foreground'
-                  : 'bg-white text-secondary/60 hover:bg-primary/10 hover:text-secondary'
+                  : 'text-secondary/60 hover:bg-primary/10 hover:text-secondary bg-white'
               )}
             >
               {label}


### PR DESCRIPTION
## 📌 개요

선생님 마이페이지 '내가 운영하는 전시회' 섹션 헤더 오른쪽에 있던 '+ 새 전시회' 버튼이 상단 'NewExhibitionBanner'와 기능이 중복되어, 해당 자리를 전시회 상태 필터 탭으로 교체했습니다.

## 🔍 변경 사항

- '+ 새 전시회' 버튼 제거
- 전체 / 진행중 / 예정됨 / 종료 상태 필터 탭 추가
- 'ExhibitionList'를 Client Component로 전환 ('useState' 사용)
- 필터 버튼 스타일을 위시리스트, 내 작품 모아보기의 'FilterTab'과 동일하게 구현
- 필터 결과가 없을 때 빈 상태 메시지("해당되는 전시회가 없습니다.") 노출

## 🔗 관련 이슈 번호

close #113 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="927" height="496" alt="스크린샷 2026-05-15 오후 4 37 19" src="https://github.com/user-attachments/assets/a74259ca-fe93-47eb-9ce9-ce1c1a63e97a" />
<img width="737" height="364" alt="스크린샷 2026-05-15 오후 4 37 34" src="https://github.com/user-attachments/assets/c5f25d9c-3bba-4883-8fbd-d523541ecf5c" />
<img width="737" height="364" alt="스크린샷 2026-05-15 오후 4 37 39" src="https://github.com/user-attachments/assets/9e4ef647-f1f2-4254-b230-33302d5d0e51" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- UI가 변경된 거라서 피그잼에도 수정한 페이지 디자인으로 변경해서 올려놓겠습니다!
