### PR TITLE
[PR] 전시회 생성페이지 DatePicker 수정, 전시회 관람페이지 모달 제목,학원이름 연동

### DIFF
--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -70,12 +70,21 @@ export default function GalleryExhibitionPage() {
             >
               🎨
             </div>
-            <p className={'text-secondary text-[20px] font-bold'}>
-              봄의 소리전
-            </p>
-            <p className={'text-secondary/40 -mt-5 text-[14px]'}>
-              해피아트 미술학원
-            </p>
+            {isInitReady ? (
+              <>
+                <p className={'text-secondary text-[20px] font-bold'}>
+                  {exhibitionDetails.title ?? '전시회'}
+                </p>
+                <p className={'text-secondary/40 -mt-5 text-[14px]'}>
+                  {exhibitionDetails.host ?? '학원'}
+                </p>
+              </>
+            ) : (
+              <>
+                <div className="h-5 w-20 animate-pulse rounded-md bg-gray-200"></div>
+                <div className="-mt-3 h-3 w-32 animate-pulse rounded-md bg-gray-200"></div>
+              </>
+            )}
             <div
               className={
                 'bg-primary/10 flex w-full flex-col gap-1 rounded-lg p-4'

--- a/src/components/galleryCreate/CreateGalleryPage.tsx
+++ b/src/components/galleryCreate/CreateGalleryPage.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import CreateGalleryFormWrapper from '@/components/galleryCreate/FormWrapper';
 import { FaArrowRight } from 'react-icons/fa';
 import {
@@ -14,6 +14,7 @@ import { postNewExhibition } from '@/service/exhibitions';
 import { useRouter } from 'next/navigation';
 import { UIFormProps } from '@/types/gallery';
 import ImageUploadBox from '@/components/exhibition/manage/imageUploadBox';
+import { useEffect } from 'react';
 export default function CreateGalleryPage({
   institution,
 }: {
@@ -22,8 +23,8 @@ export default function CreateGalleryPage({
   const router = useRouter();
   const {
     register,
-    watch,
     control,
+    setValue,
     formState: { isValid, errors, isSubmitting },
     handleSubmit,
   } = useForm<UIFormProps>({
@@ -37,6 +38,9 @@ export default function CreateGalleryPage({
       endDate: null,
     },
   });
+  const today = new Date().toISOString().split('T')[0];
+  const startDate = useWatch({ control, name: 'startDate' });
+  const endDate = useWatch({ control, name: 'endDate' });
 
   const submitHandler = async (e: UIFormProps) => {
     const formData = new FormData();
@@ -66,6 +70,15 @@ export default function CreateGalleryPage({
       console.log(err);
     }
   };
+
+  useEffect(() => {
+    if (!startDate || !endDate) return;
+
+    if (endDate < startDate) {
+      setValue('endDate', null);
+    }
+  }, [startDate, endDate, setValue]);
+
   return (
     <>
       <div className={'flex w-full flex-col items-center px-[20px] py-[40px]'}>
@@ -168,6 +181,7 @@ export default function CreateGalleryPage({
                         'w-full bg-transparent text-[16px] font-bold text-black outline-none'
                       }
                       type={'date'}
+                      min={today}
                     />
                   </CreateGalleryFormWrapper>
                 </div>
@@ -180,15 +194,15 @@ export default function CreateGalleryPage({
                     <input
                       {...register('endDate', {
                         validate: (value) => {
-                          const start = watch('startDate');
-                          if (!value) return true;
-                          return value >= start || false;
+                          if (!value || !startDate) return true;
+                          return value >= startDate;
                         },
                       })}
                       className={
                         'w-full bg-transparent text-[16px] font-bold text-black outline-none'
                       }
                       type={'date'}
+                      min={startDate || today}
                     />
                   </CreateGalleryFormWrapper>
                   {errors.endDate && (


### PR DESCRIPTION
## 📌 개요

전시 생성 폼에서 날짜 입력 시 발생할 수 있는 잘못된 선택을 방지하기 위해 날짜 유효성 검증 로직을 추가했습니다.  
시작일 이전 날짜를 종료일로 선택할 수 없도록 제한하고, 시작일이 변경되었을 때 기존 종료일이 시작일보다 이전이면 자동으로 초기화되도록 개선 했습니다.
** 전시회 관람페이지 모달에 제목, 학원이름 연동 추가했습니다.

## 🔍 변경 사항

- 시작일 이전 날짜 선택을 방지하기 위해 input date에 min 속성 추가
- 종료일이 시작일보다 이전일 경우 선택되지 않도록 검증 로직 추가
- startDate 변경 시 기존 endDate가 더 이전 날짜이면 자동 초기화 처리

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #115 

## 📸 스크린샷 (UI 변경 시 필수)

> 변경된 UI 스크린샷을 보여주세요.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
