### PR TITLE
[PR] 전시회상세 작품 좋아요 오류 수정

### DIFF
--- a/src/components/exhibition/workDialog.tsx
+++ b/src/components/exhibition/workDialog.tsx
@@ -69,12 +69,6 @@ export default function WorkDialog({
     e.preventDefault();
     e.stopPropagation();
 
-    if (!isLoggedIn) {
-      alert('로그인이 필요한 기능입니다.');
-      router.push('/login');
-      return;
-    }
-
     if (isPending) return;
 
     // 백업용
@@ -89,6 +83,7 @@ export default function WorkDialog({
     try {
       setIsPending(true);
       await toggleArtworkLike(exhibitionId, work.id, nextLiked);
+      router.refresh();
     } catch (err) {
       console.error('Like Error:', err);
       setLiked(previousLiked);
@@ -192,7 +187,7 @@ export default function WorkDialog({
 
           {!isLoggedIn && (
             <p className="text-secondary/50 text-center text-xs">
-              좋아요 및 위시리스트 기능은 로그인 후 이용 가능합니다
+              좋아요&#40;위시리스트&#41; 기능은 로그인 후 이용 가능합니다
             </p>
           )}
         </div>

--- a/src/components/galleryExhibition/threejs/Room.tsx
+++ b/src/components/galleryExhibition/threejs/Room.tsx
@@ -10,6 +10,7 @@ import Walls from '@/components/galleryExhibition/threejs/Walls';
 import InnerWalls from '@/components/galleryExhibition/threejs/InnerWall';
 import Ceiling from '@/components/galleryExhibition/threejs/Ceiling';
 import { User } from '@supabase/supabase-js';
+import { useRouter } from 'next/navigation';
 
 export default function Room({
   init,
@@ -46,6 +47,7 @@ export default function Room({
   const prevIndexRef = useRef<number>(-1);
 
   const closestPaintingRef = useRef<GalleryUIArtworkProps | null>(null);
+  const router = useRouter();
 
   useFrame(({ camera }) => {
     camera.getWorldDirection(tempForward.current);
@@ -132,6 +134,8 @@ export default function Room({
 
       try {
         await likesToggle(exhibitionId, closestId);
+
+        router.refresh();
       } catch (e) {
         console.log(e);
         setArtworks(prevArtworks!);

--- a/src/lib/exhibition/queries.ts
+++ b/src/lib/exhibition/queries.ts
@@ -234,7 +234,7 @@ export async function fetchExhibitionDetail(
       teacher_id,
       likes_count,
       profile:profiles!teacher_id ( institution ),
-      artworks ( id, title, artist_name, description, image_url, likes_count )
+      artworks ( id, title, artist_name, description, image_url )
     `
     )
     .eq('id', exhibitionId)
@@ -260,16 +260,25 @@ export async function fetchExhibitionDetail(
   }
 
   // 작품에 대한 liked
-  let likedArtworkIds = new Set<string>();
-  if (currentUserId && rawData.artworks.length) {
-    const artworkId = rawData.artworks.map((row) => row.id);
-    const { data: likedRows } = await supabase
-      .from('artwork_likes')
-      .select('artwork_id')
-      .eq('user_id', currentUserId)
-      .in('artwork_id', artworkId);
+  const artworkIds = rawData.artworks.map((row) => row.id);
+  const likesCountMap = new Map<string, number>();
+  const likedArtworkIds = new Set<string>();
 
-    likedArtworkIds = new Set((likedRows ?? []).map((r) => r.artwork_id));
+  if (artworkIds.length > 0) {
+    const { data: allLikes } = await supabase
+      .from('artwork_likes')
+      .select('artwork_id, user_id')
+      .in('artwork_id', artworkIds);
+
+    for (const row of allLikes ?? []) {
+      likesCountMap.set(
+        row.artwork_id,
+        (likesCountMap.get(row.artwork_id) ?? 0) + 1
+      );
+      if (currentUserId && row.user_id === currentUserId) {
+        likedArtworkIds.add(row.artwork_id);
+      }
+    }
   }
 
   const profile = Array.isArray(rawData.profile)
@@ -295,7 +304,7 @@ export async function fetchExhibitionDetail(
       artist: work.artist_name,
       image: work.image_url,
       description: work.description,
-      likes: work.likes_count,
+      likes: likesCountMap.get(work.id) ?? 0,
       liked: likedArtworkIds.has(work.id),
     })),
   };

--- a/src/lib/exhibition/queries.ts
+++ b/src/lib/exhibition/queries.ts
@@ -260,7 +260,7 @@ export async function fetchExhibitionDetail(
   }
 
   // 작품에 대한 liked
-  const artworkIds = rawData.artworks.map((row) => row.id);
+  const artworkIds = (rawData.artworks ?? []).map((row) => row.id);
   const likesCountMap = new Map<string, number>();
   const likedArtworkIds = new Set<string>();
 

--- a/src/types/exhibitionList.ts
+++ b/src/types/exhibitionList.ts
@@ -51,7 +51,6 @@ export type ArtworkRow = {
   artist_name: string;
   image_url: string;
   description: string | null;
-  likes_count: number;
 };
 
 export type ReviewRow = {

--- a/supabase/migration/0003_drop_artworks_likes_count.sql
+++ b/supabase/migration/0003_drop_artworks_likes_count.sql
@@ -1,0 +1,8 @@
+-- 새 마이그레이션 파일: 0003_drop_artworks_likes_count.sql
+-- 이유: artwork_likes에서 직접 count하는 방식으로 통일.
+-- artworks.likes_count는 어디서도 읽지 않으므로 컬럼/트리거/인덱스 제거.
+
+drop trigger if exists artwork_likes_count_trg on artwork_likes;
+drop function if exists bump_artwork_likes_count();
+drop index if exists artworks_popular_idx;
+alter table artworks drop column if exists likes_count;

--- a/supabase/migration/0004_exhibitions_likes_count_security_definer.sql
+++ b/supabase/migration/0004_exhibitions_likes_count_security_definer.sql
@@ -1,0 +1,20 @@
+create or replace function bump_exhibition_likes_count()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if tg_op = 'INSERT' then
+    update exhibitions
+       set likes_count = likes_count + 1
+     where id = new.exhibition_id;
+    return new;
+  elsif tg_op = 'DELETE' then
+    update exhibitions
+       set likes_count = greatest(likes_count - 1, 0)
+     where id = old.exhibition_id;
+    return old;
+  end if;
+  return null;
+end $$;


### PR DESCRIPTION
## 📌 개요

전시회 상세페이지의 작품 좋아요와 전시관의 작품 좋아요 간의 오류가 발생했습니다.

## 🔍 변경 사항

- 전시회 상세 페이지의 artworks.likes_count -> artwork_likes테이블로 수정
- artwors db 수정
- exhibitions.likes_count 권한 수정

## 🔗 관련 이슈 번호

- close #112 

## 📸 스크린샷 (UI 변경 시 필수)

변경된 UI가 없습니다.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

artworks의 likes_count를 사용하지 않아 삭제 했습니다. 추후 인기순 + 페이지네이션 기능이 추가된다면 필요합니다.
exhibitions 테이블의 likes_count는 기존에 소유자 권한만 수정,삭제 등이 가능했습니다. 이로 인해 likes가 변하지 않을 수 있는 오류를 방지하고자 likes_count의 권한만 우회하여 열어두었습니다. 이 점 참고 바랍니다.
