### PR TITLE
[PR] 메인, 리뷰 페이지네이션 클릭시 상단으로 이동 추가

### DIFF
--- a/src/components/exhibition/reviewSection.tsx
+++ b/src/components/exhibition/reviewSection.tsx
@@ -48,6 +48,9 @@ export default function ReviewSection({
 
   const handlePageChange = async (page: number) => {
     if (page === currentPage) return;
+    document
+      .getElementById('review-section')
+      ?.scrollIntoView({ block: 'start' });
     try {
       await loadPage(page);
     } catch (err) {
@@ -93,7 +96,10 @@ export default function ReviewSection({
   };
 
   return (
-    <section className="space-y-4 rounded-2xl bg-white p-6 shadow-[0_2px_8px_rgba(44,40,38,0.06)]">
+    <section
+      id="review-section"
+      className="scroll-mt-20 space-y-4 rounded-2xl bg-white p-6 shadow-[0_2px_8px_rgba(44,40,38,0.06)]"
+    >
       <strong className="text-secondary mb-3 block text-lg font-bold">
         관람 후기 ({totalCount})
       </strong>

--- a/src/components/home/exhibitionList.tsx
+++ b/src/components/home/exhibitionList.tsx
@@ -24,7 +24,7 @@ export default function ExhibitionList({
   const [isPending, startTransition] = useTransition();
 
   return (
-    <section className="space-y-6">
+    <section id="exhibition-list" className="scroll-mt-20 space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <ExhibitionFilter
           value={sort}

--- a/src/components/home/listPagination.tsx
+++ b/src/components/home/listPagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   Pagination,
   PaginationContent,
@@ -34,6 +36,12 @@ export default function ListPagination({
     return queryString ? `/?${queryString}` : '/';
   };
 
+  const scrollToList = () => {
+    document
+      .getElementById('exhibition-list')
+      ?.scrollIntoView({ block: 'start' });
+  };
+
   const start = Math.max(1, currentPage - 2);
   const end = Math.min(totalPages, currentPage + 2);
   const range = Array.from({ length: end - start + 1 }, (_, i) => start + i);
@@ -43,14 +51,19 @@ export default function ListPagination({
       <PaginationContent>
         {currentPage > 1 && (
           <PaginationItem>
-            <PaginationPrevious href={makeHref(currentPage - 1)} />
+            <PaginationPrevious
+              href={makeHref(currentPage - 1)}
+              onClick={scrollToList}
+            />
           </PaginationItem>
         )}
 
         {start > 1 && (
           <>
             <PaginationItem>
-              <PaginationLink href={makeHref(1)}>1</PaginationLink>
+              <PaginationLink href={makeHref(1)} onClick={scrollToList}>
+                1
+              </PaginationLink>
             </PaginationItem>
             {start > 2 && (
               <PaginationItem>
@@ -62,7 +75,11 @@ export default function ListPagination({
 
         {range.map((p) => (
           <PaginationItem key={p}>
-            <PaginationLink href={makeHref(p)} isActive={p === currentPage}>
+            <PaginationLink
+              href={makeHref(p)}
+              isActive={p === currentPage}
+              onClick={scrollToList}
+            >
               {p}
             </PaginationLink>
           </PaginationItem>
@@ -76,7 +93,10 @@ export default function ListPagination({
               </PaginationItem>
             )}
             <PaginationItem>
-              <PaginationLink href={makeHref(totalPages)}>
+              <PaginationLink
+                href={makeHref(totalPages)}
+                onClick={scrollToList}
+              >
                 {totalPages}
               </PaginationLink>
             </PaginationItem>
@@ -85,7 +105,10 @@ export default function ListPagination({
 
         {currentPage < totalPages && (
           <PaginationItem>
-            <PaginationNext href={makeHref(currentPage + 1)} />
+            <PaginationNext
+              href={makeHref(currentPage + 1)}
+              onClick={scrollToList}
+            />
           </PaginationItem>
         )}
       </PaginationContent>


### PR DESCRIPTION
## 📌 개요

메인, 리뷰에서 pagination클릭시 하단에서 머물러 사용자 경험 불편합니다.

## 🔍 변경 사항

- 메인 전체 전시회 pagination클릭시 상단으로 이동 추가
- 전시회 리뷰 pagination클릭시 상단으로 이동 추가

## 🔗 관련 이슈 번호

- close #117 

## 📸 스크린샷 (UI 변경 시 필수)

변경된 UI없음

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
