### PR TITLE
[PR] 마이페이지 프로필 수정 기능 추가

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,11 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
-
-const patchSchema = z.object({
-  name: z.string().trim().min(1, '이름을 입력해주세요.'),
-  institution: z.string().trim().optional(),
-});
+import { profilePatchSchema } from '@/lib/schemas/profile';
 
 export async function PATCH(req: NextRequest) {
   const supabase = await createClient();
@@ -18,7 +13,7 @@ export async function PATCH(req: NextRequest) {
   }
 
   const body = await req.json();
-  const result = patchSchema.safeParse(body);
+  const result = profilePatchSchema.safeParse(body);
 
   if (!result.success) {
     return NextResponse.json(

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -12,7 +12,12 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ message: 'unauthorized' }, { status: 401 });
   }
 
-  const body = await req.json();
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ message: 'invalid json body' }, { status: 400 });
+  }
   const result = profilePatchSchema.safeParse(body);
 
   if (!result.success) {

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -27,8 +27,21 @@ export async function PATCH(req: NextRequest) {
     );
   }
 
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profileError || !profile) {
+    return NextResponse.json({ message: 'profile not found' }, { status: 404 });
+  }
+
   const updates: Record<string, string> = { username: result.data.name };
   if (result.data.institution !== undefined) {
+    if (profile.role !== 'teacher') {
+      return NextResponse.json({ message: 'forbidden' }, { status: 403 });
+    }
     updates.institution = result.data.institution;
   }
 

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,45 @@
+import { createClient } from '@/lib/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const patchSchema = z.object({
+  name: z.string().trim().min(1, '이름을 입력해주세요.'),
+  institution: z.string().trim().optional(),
+});
+
+export async function PATCH(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ message: 'unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const result = patchSchema.safeParse(body);
+
+  if (!result.success) {
+    return NextResponse.json(
+      { message: result.error.issues[0].message },
+      { status: 400 }
+    );
+  }
+
+  const updates: Record<string, string> = { username: result.data.name };
+  if (result.data.institution !== undefined) {
+    updates.institution = result.data.institution;
+  }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update(updates)
+    .eq('id', user.id);
+
+  if (error) {
+    return NextResponse.json({ message: 'database error' }, { status: 500 });
+  }
+
+  return NextResponse.json({ message: 'ok' }, { status: 200 });
+}

--- a/src/components/myPage/ProfileCard.tsx
+++ b/src/components/myPage/ProfileCard.tsx
@@ -1,3 +1,4 @@
+import ProfileEditDialog from '@/components/myPage/ProfileEditDialog';
 import type { Profile } from '@/types/myPage';
 
 interface ProfileCardProps {
@@ -13,13 +14,13 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
 
   return (
     <section className="rounded-[26px] border border-[#e8e1d7] bg-white px-9 py-7 shadow-[0_2px_8px_rgba(64,48,33,0.04)]">
-      <div className="flex items-center gap-5">
+      <div className="flex items-start gap-5">
         {/* 아바타 */}
         <div className="flex h-[68px] w-[68px] items-center justify-center rounded-[20px] bg-gradient-to-br from-[#f5bf45] to-[#ff8f74] text-[22px] font-bold text-white">
           {profile.name.slice(0, 1)}
         </div>
 
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <div className="mb-1 flex items-center gap-3">
             <h1 className="text-[18px] font-bold text-[#2b2724]">
               {profile.name}
@@ -39,6 +40,8 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
             </p>
           )}
         </div>
+
+        <ProfileEditDialog profile={profile} />
       </div>
     </section>
   );

--- a/src/components/myPage/ProfileEditDialog.tsx
+++ b/src/components/myPage/ProfileEditDialog.tsx
@@ -41,22 +41,26 @@ export default function ProfileEditDialog({ profile }: Props) {
       body.institution = institution.trim();
     }
 
-    const res = await fetch('/api/profile', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
+    try {
+      const res = await fetch('/api/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
 
-    setLoading(false);
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.message ?? '저장에 실패했습니다.');
+        return;
+      }
 
-    if (!res.ok) {
-      const data = await res.json();
-      setError(data.message ?? '저장에 실패했습니다.');
-      return;
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError('네트워크 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
     }
-
-    setOpen(false);
-    router.refresh();
   }
 
   return (

--- a/src/components/myPage/ProfileEditDialog.tsx
+++ b/src/components/myPage/ProfileEditDialog.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Pencil } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import type { Profile } from '@/types/myPage';
+
+interface Props {
+  profile: Profile;
+}
+
+export default function ProfileEditDialog({ profile }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(profile.name);
+  const [institution, setInstitution] = useState(
+    profile.role === 'teacher' ? profile.academy_name : ''
+  );
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit() {
+    if (!name.trim()) {
+      setError('이름을 입력해주세요.');
+      return;
+    }
+    setError('');
+    setLoading(true);
+
+    const body: Record<string, string> = { name: name.trim() };
+    if (profile.role === 'teacher') {
+      body.institution = institution.trim();
+    }
+
+    const res = await fetch('/api/profile', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    setLoading(false);
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.message ?? '저장에 실패했습니다.');
+      return;
+    }
+
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <button className="rounded-full p-1.5 text-[#a09a92] transition-colors hover:bg-[#f5efe6] hover:text-[#7a6e65]" />
+        }
+        aria-label="프로필 편집"
+      >
+        <Pencil size={15} />
+      </DialogTrigger>
+
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-[16px] font-bold text-[#26221f]">
+            프로필 수정
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 py-1">
+          <div>
+            <label className="mb-1.5 block text-[13px] font-medium text-[#5a534c]">
+              이름
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full rounded-[12px] border border-[#e8e1d7] bg-[#faf7f2] px-4 py-2.5 text-[14px] text-[#26221f] outline-none focus:border-[#f1c792] focus:ring-2 focus:ring-[#f1c792]/30"
+              placeholder="이름을 입력하세요"
+            />
+          </div>
+
+          {profile.role === 'teacher' && (
+            <div>
+              <label className="mb-1.5 block text-[13px] font-medium text-[#5a534c]">
+                학원명
+              </label>
+              <input
+                type="text"
+                value={institution}
+                onChange={(e) => setInstitution(e.target.value)}
+                className="w-full rounded-[12px] border border-[#e8e1d7] bg-[#faf7f2] px-4 py-2.5 text-[14px] text-[#26221f] outline-none focus:border-[#f1c792] focus:ring-2 focus:ring-[#f1c792]/30"
+                placeholder="학원명을 입력하세요"
+              />
+            </div>
+          )}
+
+          {error && (
+            <p className="text-[12px] text-red-500">{error}</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="w-full rounded-[12px] bg-[#f0b63b] text-white hover:bg-[#e2a93a] disabled:opacity-60"
+          >
+            {loading ? '저장 중...' : '저장'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/myPage/ProfileEditDialog.tsx
+++ b/src/components/myPage/ProfileEditDialog.tsx
@@ -106,9 +106,7 @@ export default function ProfileEditDialog({ profile }: Props) {
             </div>
           )}
 
-          {error && (
-            <p className="text-[12px] text-red-500">{error}</p>
-          )}
+          {error && <p className="text-[12px] text-red-500">{error}</p>}
         </div>
 
         <DialogFooter>

--- a/src/lib/schemas/profile.ts
+++ b/src/lib/schemas/profile.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const profilePatchSchema = z.object({
+  name: z.string().trim().min(1, '이름을 입력해주세요.'),
+  institution: z.string().trim().optional(),
+});


### PR DESCRIPTION
## 📌 개요

마이페이지에서 이름과 학원명(선생님 계정)을 수정할 방법이 없어서 회원가입 이후 정보 변경이 불가능한 문제를 해결합니다.

## 🔍 변경 사항

- PATCH /api/profile 라우트 추가 -> 인증된 사용자의 username, institution 업데이트
- ProfileEditDialog 컴포넌트 추가 -> 이름/학원명 수정 폼 다이얼로그, 저장 후 router.refresh()로 즉시 반영
- ProfileCard에 편집 버튼(Pencil 아이콘) 추가 및 Dialog 연결

## 🔗 관련 이슈 번호

close #119 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="2944" height="2182" alt="localhost_3000_myPage (3)" src="https://github.com/user-attachments/assets/4cbcf756-97e7-4fa5-952e-51f6a61a4f36" />


<img width="1167" height="714" alt="스크린샷 2026-05-18 오후 4 07 14" src="https://github.com/user-attachments/assets/bf54f9fb-2313-48b7-8147-e48bdec25c21" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- 피그잼 디자인 수정해 놓았습니다~
- 이메일은 수정 불가입니다. (Supabase Auth 관리 영역)
- 선생님 계정에만 학원명 필드 노출
