### PR TITLE
[PR] 작품 개수에 따른 방 크기 조정기능 추가

### DIFF
--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -36,6 +36,7 @@ export default function GalleryExhibitionPage() {
           supabase.auth.getUser(),
           getExhibitionDetails(id),
         ]);
+        if (artworksRes.length === 0) throw new Error('no artworks found');
 
         setExhibitionDetails(exhibitionDetails);
         setGalleryInit(artworksRes);

--- a/src/components/exhibition/manage/addWorkDialog.tsx
+++ b/src/components/exhibition/manage/addWorkDialog.tsx
@@ -16,7 +16,7 @@ import ImageUploadBox from './imageUploadBox';
 import { Controller, useForm } from 'react-hook-form';
 import { useParams, useRouter } from 'next/navigation';
 import { postArtWorksByExhibitionId } from '@/service/artworks';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface AddWorkDialogProps {
   triggerLabel?: string;
@@ -44,6 +44,7 @@ export default function AddWorkDialog({
     register,
     control,
     setError,
+    reset,
     formState: { isValid, isSubmitting, errors },
     handleSubmit,
   } = useForm<ArtworkFormUi>({
@@ -85,6 +86,9 @@ export default function AddWorkDialog({
     }
   };
 
+  useEffect(() => {
+    if (!open) reset();
+  }, [open, reset]);
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger

--- a/src/components/galleryExhibition/threejs/Room.tsx
+++ b/src/components/galleryExhibition/threejs/Room.tsx
@@ -163,7 +163,7 @@ export default function Room({
     return () => {
       window.removeEventListener('keydown', handler);
     };
-  }, [exhibitionId, user]);
+  }, [exhibitionId, user, router]);
 
   return (
     <>

--- a/src/components/galleryExhibition/threejs/Scene.tsx
+++ b/src/components/galleryExhibition/threejs/Scene.tsx
@@ -7,6 +7,11 @@ import Room from '@/components/galleryExhibition/threejs/Room';
 import Player from '@/components/galleryExhibition/threejs/Player';
 import { User } from '@supabase/supabase-js';
 
+function getGridSize(artworkCount: number) {
+  if (artworkCount <= 4) return 1;
+  if (artworkCount <= 10) return 2;
+  return 3;
+}
 export default function Scene2({
   exhibitionId,
   ready,
@@ -18,9 +23,12 @@ export default function Scene2({
   init: GalleryUIArtworkProps[];
   user: User | null;
 }) {
-  // console.log(init)
-  const size = 21;
-  const height = size * 0.3;
+  const artworkCount = init.length;
+  const cellSize = 7;
+  const gridSize = getGridSize(artworkCount);
+  const size = gridSize * cellSize;
+
+  const height = 6;
   const { innerWalls, startPosition } = useMemo(
     () => generateGalleryWalls(size),
     [size]

--- a/src/components/galleryExhibition/threejs/Scene.tsx
+++ b/src/components/galleryExhibition/threejs/Scene.tsx
@@ -26,14 +26,17 @@ export default function Scene2({
   const artworkCount = init.length;
   const cellSize = 7;
   const gridSize = getGridSize(artworkCount);
-  const size = gridSize * cellSize;
+  const roomSize = gridSize * cellSize;
 
   const height = 6;
   const { innerWalls, startPosition } = useMemo(
-    () => generateGalleryWalls(size),
-    [size]
+    () => generateGalleryWalls(roomSize, gridSize, cellSize),
+    [roomSize, gridSize, cellSize]
   );
-  const walls = useMemo(() => createWalls(size, height), [size, height]);
+  const walls = useMemo(
+    () => createWalls(roomSize, height),
+    [roomSize, height]
+  );
 
   const { active, loaded, total } = useProgress();
 
@@ -49,7 +52,7 @@ export default function Scene2({
           walls={walls}
           innerWalls={innerWalls}
           init={init}
-          size={size}
+          size={roomSize}
           height={height}
         />
         <ambientLight intensity={1} />

--- a/src/lib/gallery/createWalls.ts
+++ b/src/lib/gallery/createWalls.ts
@@ -1,8 +1,11 @@
 import { Cell, WAllType } from '@/types/gallery';
 
-export function generateGalleryWalls(roomSize: number) {
-  const cellSize = 7;
-  const size = Math.floor(roomSize / cellSize);
+export function generateGalleryWalls(
+  roomSize: number,
+  gridSize: number,
+  cellSize: number
+) {
+  const size = gridSize;
   const half = roomSize / 2;
 
   const startPosition = {

--- a/src/lib/gallery/createWalls.ts
+++ b/src/lib/gallery/createWalls.ts
@@ -1,8 +1,8 @@
 import { Cell, WAllType } from '@/types/gallery';
 
 export function generateGalleryWalls(roomSize: number) {
-  const size = 3;
-  const cellSize = roomSize / size;
+  const cellSize = 7;
+  const size = Math.floor(roomSize / cellSize);
   const half = roomSize / 2;
 
   const startPosition = {
@@ -96,7 +96,6 @@ export function generateGalleryWalls(roomSize: number) {
 
   // 3. 벽 생성
   const walls: WAllType[] = [];
-
   for (let x = 0; x < size; x++) {
     for (let z = 0; z < size; z++) {
       const cell = grid[x][z];
@@ -104,7 +103,7 @@ export function generateGalleryWalls(roomSize: number) {
       const cx = -half + x * cellSize + cellSize / 2;
       const cz = -half + z * cellSize + cellSize / 2;
 
-      const h = roomSize * 0.2;
+      const h = 5;
       const t = 0.3;
 
       //똑같은 두께의 벽이 동일좌표에 생성되니까 텍스쳐가 깨질 가능성? -> 벽을 z축으로 조금 더 미는거?


### PR DESCRIPTION
## 📌 개요

> 그림 개수에 따라 전시관 크기가 동적으로 변경되도록 수정했습니다.
## 🔍 변경 사항

> 주요 변경 사항을 설명해주세요.

작품 개수에 따라 전시관 그리드 크기를 고정 규칙으로 설정
전시 공간 크기와 내부 벽 생성 로직이 해당 그리드에 맞게 동작하도록 수정
 
- 1~4 : 방 크기 그리드 1으로 고정
- 5~10 : 방 크기 그리드 2으로 고정
- 11~20: 방 크기 그리드 3으로 고정

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #123 

## 📸 스크린샷 (UI 변경 시 필수)

> 변경된 UI 스크린샷을 보여주세요.

## 🧪 테스트 결과

- [ ] 코드가 정상 작동하는 지 확인했나요?
- [ ] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [ ] 라우팅이 정상 작동하는 지 확인했나요?
- [ ] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
지금 그림개수가 0개이거나 20개가 넘어가면 오류가 뜨는데 심화 프로젝트때 수정 하겠습니다.
무료 플랜에서는 최대 20개 까지만 등록할 수 있게 하고 , 추후 구독 시스템 도입하면 더 늘릴 수 있게 변경하겠습니다.