### PR TITLE
[PR] 작품 상세 모달 공통 컴포넌트 추출

### DIFF
--- a/src/components/exhibition/WorkDialog.tsx
+++ b/src/components/exhibition/WorkDialog.tsx
@@ -1,19 +1,11 @@
 'use client';
 
 import Image from 'next/image';
-import { Download, Heart, X } from 'lucide-react';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { toggleArtworkLike } from '@/lib/artwork/service';
-import { cn } from '@/lib/utils';
+import { useState } from 'react';
+import { likesToggle } from '@/lib/artwork/service';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import { useImageDownload } from '@/hooks/useImageDownload';
+import ArtworkDetailContent from '@/components/ui/ArtworkDetailContent';
 
 export interface Work {
   id: string;
@@ -40,32 +32,37 @@ export default function WorkDialog({
   exhibitionHost,
   isLoggedIn = false,
 }: WorkDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const {
+    liked,
+    likes,
+    isPending,
+    toggle: handleLike,
+  } = useOptimisticLike({
+    initialLiked: work.liked,
+    initialLikes: work.likes,
+    onToggle: () => likesToggle(exhibitionId, work.id),
+    refreshOnSuccess: true,
+  });
+
   const { download } = useImageDownload();
 
-  const handleImageDownload = async (imageUrl: string, title: string) => {
+  const handleDownload = async () => {
     try {
-      await download(imageUrl, title);
+      await download(work.image, `${work.title}.jpg`);
     } catch (err) {
       console.error('Image Download Error', err);
       alert('이미지 다운로드에 실패했습니다. 다시 시도해주세요.');
     }
   };
 
-  const {
-    liked,
-    likes,
-    toggle: handleClick,
-  } = useOptimisticLike({
-    initialLiked: work.liked,
-    initialLikes: work.likes,
-    onToggle: (nextLiked) =>
-      toggleArtworkLike(exhibitionId, work.id, nextLiked),
-    refreshOnSuccess: true,
-  });
-
   return (
-    <Dialog>
-      <DialogTrigger className="group flex w-full flex-col overflow-hidden rounded-2xl bg-white text-left shadow-[0_2px_8px_rgba(44,40,38,0.06)] transition-all hover:shadow-[0_8px_24px_rgba(44,40,38,0.12)]">
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="group flex w-full flex-col overflow-hidden rounded-2xl bg-white text-left shadow-[0_2px_8px_rgba(44,40,38,0.06)] transition-all hover:shadow-[0_8px_24px_rgba(44,40,38,0.12)]"
+      >
         <div className="relative aspect-4/3 overflow-hidden bg-[#F5EFE0]">
           <Image
             src={work.image}
@@ -81,87 +78,25 @@ export default function WorkDialog({
             {work.artist}
           </p>
         </div>
-      </DialogTrigger>
+      </button>
 
-      <DialogContent
-        className="w-[calc(100%-2rem)] max-w-4xl overflow-hidden rounded-2xl bg-white p-0 sm:max-w-lg"
-        showCloseButton={false}
-      >
-        <DialogClose
-          aria-label="닫기"
-          className="absolute top-4 right-4 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-colors hover:bg-white/90"
-        >
-          <X className="text-secondary h-4 w-4" />
-        </DialogClose>
-        {/* 작품 이미지 */}
-        <div className="relative aspect-4/3 w-full bg-[#F5EFE0]">
-          <Image
-            src={work.image}
-            alt={work.title}
-            fill
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
-            className="object-cover"
-          />
-        </div>
-        {/* 정보 영역 */}
-        <div className="space-y-4 p-6">
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
-              <DialogTitle className="text-secondary text-2xl font-bold">
-                {work.title}
-              </DialogTitle>
-              <p className="text-secondary/60 text-sm">작가: {work.artist}</p>
-            </div>
-
-            <div className="flex items-center gap-1.5">
-              <button
-                type="button"
-                disabled={!isLoggedIn}
-                onClick={handleClick}
-                aria-label="좋아요"
-                className={cn(
-                  'text-secondary/60 hover:bg-primary/10 inline-flex items-center gap-1 rounded-full px-2 py-1 text-sm transition-colors disabled:opacity-50 disabled:hover:bg-transparent',
-                  liked
-                    ? 'bg-red-50 text-red-500'
-                    : 'text-secondary/60 hover:bg-primary/10'
-                )}
-              >
-                <Heart className={cn('h-4 w-4', liked && 'fill-red-500')} />
-                {likes ?? 0}
-              </button>
-              <button
-                type="button"
-                onClick={() => handleImageDownload(work.image, work.title)}
-                aria-label="다운로드"
-                className="text-secondary/60 hover:bg-primary/10 inline-flex h-8 w-8 items-center justify-center rounded-full transition-colors"
-              >
-                <Download className="h-4 w-4" />
-              </button>
-            </div>
-          </div>
-
-          {work.description && (
-            <DialogDescription className="text-secondary/70 text-sm leading-relaxed">
-              {work.description}
-            </DialogDescription>
-          )}
-
-          <div className="border-t border-[#F0EAD8] pt-4">
-            <div className="text-secondary/60 flex items-center gap-2 text-sm">
-              <span className="bg-primary inline-block h-1.5 w-1.5 rounded-full" />
-              <span>
-                {exhibitionTitle} · {exhibitionHost}
-              </span>
-            </div>
-          </div>
-
-          {!isLoggedIn && (
-            <p className="text-secondary/50 text-center text-xs">
-              좋아요&#40;위시리스트&#41; 기능은 로그인 후 이용 가능합니다
-            </p>
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
+      {open && (
+        <ArtworkDetailContent
+          image={work.image}
+          title={work.title}
+          artist={work.artist}
+          description={work.description}
+          likes={likes}
+          liked={liked}
+          isPending={isPending}
+          isLoggedIn={isLoggedIn}
+          exhibitionTitle={exhibitionTitle}
+          host={exhibitionHost}
+          onClose={() => setOpen(false)}
+          onLike={handleLike}
+          onDownload={handleDownload}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/exhibition/WorkDialog.tsx
+++ b/src/components/exhibition/WorkDialog.tsx
@@ -30,7 +30,7 @@ export default function WorkDialog({
   exhibitionId,
   exhibitionTitle,
   exhibitionHost,
-  isLoggedIn = false,
+  isLoggedIn,
 }: WorkDialogProps) {
   const [open, setOpen] = useState(false);
 

--- a/src/components/my-artworks/ArtworkModal.tsx
+++ b/src/components/my-artworks/ArtworkModal.tsx
@@ -1,22 +1,23 @@
 'use client';
 
-import { useEffect } from 'react';
-import Image from 'next/image';
 import { likesToggle } from '@/lib/artwork/service';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import { useImageDownload } from '@/hooks/useImageDownload';
 import { Artwork } from '@/types/artwork';
+import ArtworkDetailContent from '@/components/ui/ArtworkDetailContent';
 
 interface ArtworkModalProps {
   artwork: Artwork;
   onClose: () => void;
   onLikeChange?: (liked: boolean, newCount: number) => void;
+  isLoggedIn?: boolean;
 }
 
 export default function ArtworkModal({
   artwork,
   onClose,
   onLikeChange,
+  isLoggedIn,
 }: ArtworkModalProps) {
   const {
     liked,
@@ -32,18 +33,6 @@ export default function ArtworkModal({
 
   const { download } = useImageDownload();
 
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleKey);
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.removeEventListener('keydown', handleKey);
-      document.body.style.overflow = '';
-    };
-  }, [onClose]);
-
   const handleDownload = async () => {
     try {
       await download(artwork.imageUrl, `${artwork.title}.jpg`);
@@ -53,110 +42,20 @@ export default function ArtworkModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-full max-w-132.5 overflow-hidden rounded-3xl shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 닫기 버튼 */}
-        <button
-          onClick={onClose}
-          className="absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-[#1A1A1A] shadow-sm transition-colors hover:bg-white"
-        >
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-            <path
-              d="M1 1l12 12M13 1L1 13"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-            />
-          </svg>
-        </button>
-
-        {/* 이미지 */}
-        <div className="relative aspect-4/3 w-full bg-[#E8E5DE]">
-          <Image
-            src={artwork.imageUrl}
-            alt={artwork.title}
-            fill
-            className="object-cover"
-            sizes="530px"
-          />
-        </div>
-
-        {/* 정보 패널 */}
-        <div className="bg-white px-6 pt-5 pb-6">
-          {/* 제목 + 액션 버튼들 */}
-          <div className="mb-1 flex items-start justify-between gap-3">
-            <h2 className="text-[20px] font-bold text-[#1A1A1A]">
-              {artwork.title}
-            </h2>
-            <div className="flex shrink-0 items-center gap-1.5">
-              {/* 좋아요 */}
-              <button
-                onClick={handleLike}
-                disabled={isPending}
-                className="flex items-center gap-1.5 rounded-full border border-[#EDEBE4] px-3.5 py-1.5 transition-colors hover:bg-[#F5F0E8] disabled:opacity-50"
-              >
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M8 13.5S2 9.8 2 5.9A3.4 3.4 0 018 3.6 3.4 3.4 0 0114 5.9C14 9.8 8 13.5 8 13.5z"
-                    stroke={liked ? '#F4845F' : '#1A1A1A'}
-                    fill={liked ? '#F4845F' : 'none'}
-                    strokeWidth="1.4"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-                <span className="text-[13px] font-medium text-[#1A1A1A]">
-                  {likesCount}
-                </span>
-              </button>
-              {/* 다운로드 */}
-              <button
-                onClick={handleDownload}
-                className="flex h-8 w-8 items-center justify-center rounded-full border border-[#EDEBE4] text-[#1A1A1A] transition-colors hover:bg-[#F5F0E8]"
-              >
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M8 2v8M5 7l3 3 3-3"
-                    stroke="currentColor"
-                    strokeWidth="1.4"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M2 12h12"
-                    stroke="currentColor"
-                    strokeWidth="1.4"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </button>
-            </div>
-          </div>
-
-          {/* 작가 */}
-          <p className="mb-3 text-[13px] text-[#888780]">
-            작가: {artwork.artist}
-          </p>
-
-          {/* 설명 */}
-          <p className="mb-4 text-[14px] leading-relaxed text-[#444340]">
-            {artwork.description}
-          </p>
-
-          {/* 전시회 · 미술학원 */}
-          <div className="flex items-center gap-1.5">
-            <span className="h-1.5 w-1.5 rounded-full bg-[#F4845F]" />
-            <span className="text-[12px] text-[#888780]">
-              {artwork.exhibitionTitle} · {artwork.academyName}
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
+    <ArtworkDetailContent
+      image={artwork.imageUrl}
+      title={artwork.title}
+      artist={artwork.artist}
+      description={artwork.description}
+      likes={likesCount}
+      liked={liked}
+      isPending={isPending}
+      isLoggedIn={isLoggedIn}
+      exhibitionTitle={artwork.exhibitionTitle}
+      host={artwork.academyName}
+      onClose={onClose}
+      onLike={handleLike}
+      onDownload={handleDownload}
+    />
   );
 }

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+
+export interface ArtworkDetailContentProps {
+  image: string;
+  title: string;
+  artist: string;
+  description?: string;
+  likes: number;
+  liked: boolean;
+  isPending: boolean;
+  isLoggedIn?: boolean;
+  exhibitionTitle: string;
+  host: string;
+  onClose: () => void;
+  onLike: () => void;
+  onDownload: () => void;
+}
+
+export default function ArtworkDetailContent({
+  image,
+  title,
+  artist,
+  description,
+  likes,
+  liked,
+  isPending,
+  isLoggedIn,
+  exhibitionTitle,
+  host,
+  onClose,
+  onLike,
+  onDownload,
+}: ArtworkDetailContentProps) {
+  const [showLoginHint, setShowLoginHint] = useState(false);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.body.style.overflow = '';
+    };
+  }, [onClose]);
+
+  const handleLikeClick = () => {
+    if (isLoggedIn === false) {
+      setShowLoginHint(true);
+      return;
+    }
+    onLike();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-132.5 overflow-hidden rounded-3xl shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 닫기 버튼 */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-[#1A1A1A] shadow-sm transition-colors hover:bg-white"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path
+              d="M1 1l12 12M13 1L1 13"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+
+        {/* 이미지 */}
+        <div className="relative aspect-4/3 w-full bg-[#E8E5DE]">
+          <Image
+            src={image}
+            alt={title}
+            fill
+            className="object-cover"
+            sizes="530px"
+          />
+        </div>
+
+        {/* 정보 패널 */}
+        <div className="bg-white px-6 pt-5 pb-6">
+          <div className="mb-1 flex items-start justify-between gap-3">
+            <h2 className="text-[20px] font-bold text-[#1A1A1A]">{title}</h2>
+            <div className="flex shrink-0 items-center gap-1.5">
+              {/* 좋아요 */}
+              <button
+                onClick={handleLikeClick}
+                disabled={isPending}
+                className="flex items-center gap-1.5 rounded-full border border-[#EDEBE4] px-3.5 py-1.5 transition-colors hover:bg-[#F5F0E8] disabled:opacity-50"
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                  <path
+                    d="M8 13.5S2 9.8 2 5.9A3.4 3.4 0 018 3.6 3.4 3.4 0 0114 5.9C14 9.8 8 13.5 8 13.5z"
+                    stroke={liked ? '#F4845F' : '#1A1A1A'}
+                    fill={liked ? '#F4845F' : 'none'}
+                    strokeWidth="1.4"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                <span className="text-[13px] font-medium text-[#1A1A1A]">
+                  {likes}
+                </span>
+              </button>
+              {/* 다운로드 */}
+              <button
+                onClick={onDownload}
+                className="flex h-8 w-8 items-center justify-center rounded-full border border-[#EDEBE4] text-[#1A1A1A] transition-colors hover:bg-[#F5F0E8]"
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                  <path
+                    d="M8 2v8M5 7l3 3 3-3"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2 12h12"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <p className="mb-3 text-[13px] text-[#888780]">작가: {artist}</p>
+
+          {description && (
+            <p className="mb-4 text-[14px] leading-relaxed text-[#444340]">
+              {description}
+            </p>
+          )}
+
+          <div className="flex items-center gap-1.5">
+            <span className="h-1.5 w-1.5 rounded-full bg-[#F4845F]" />
+            <span className="text-[12px] text-[#888780]">
+              {exhibitionTitle} · {host}
+            </span>
+          </div>
+
+          {showLoginHint && (
+            <p className="mt-3 text-center text-xs text-[#E5484D]">
+              좋아요 기능은 로그인 후 이용 가능합니다
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 개요

WorkDialog와 ArtworkModal이 작품 상세 모달 UI를 각각 중복 구현하고 있었고, 두 모달의 오버레이 스타일도 상이했습니다.
공통 컴포넌트로 통합해 중복 제거 및 UI 일관성을 확보했습니다.

## 🔍 변경 사항

- ArtworkDetailContent.tsx 공통 모달 컴포넌트 생성 (overlay, 이미지, 정보 패널, 좋아요/다운로드 버튼 통합)
- WorkDialog -> shadcn Dialog 제거, 커스텀 overlay(bg-black/50)으로 교체, ArtworkDetailContent 적용
- ArtworkModal -> ArtworkDetailContent 적용, 렌더링 로직 제거
- 비로그인 좋아요 클릭 시 힌트 문구 노출 추가

## 🔗 관련 이슈 번호

close #140 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1058" height="656" alt="스크린샷 2026-05-28 오후 4 45 20" src="https://github.com/user-attachments/assets/eb14204c-c17c-4857-a43c-ba3f91dd8307" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항
