### PR TITLE
[PR] 전시관 forest 테마 프리셋 추가 

### DIFF
--- a/src/components/exhibition-gallery/models/themes/Mushroom.tsx
+++ b/src/components/exhibition-gallery/models/themes/Mushroom.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+const CAP_COLORS = ['#D04040', '#E07A30', '#C460A0', '#F08070'];
+
+const DOT_OFFSETS: [number, number, number][] = [
+  [0.18, 0.7, 0.05],
+  [-0.15, 0.72, 0.1],
+  [0.05, 0.78, -0.18],
+  [-0.05, 0.72, 0.2],
+  [0.22, 0.72, -0.15],
+];
+
+export function Mushroom(props: JSX.IntrinsicElements['group']) {
+  const [capColor] = useState(
+    () => CAP_COLORS[Math.floor(Math.random() * CAP_COLORS.length)]
+  );
+
+  return (
+    <group {...props} dispose={null}>
+      <mesh position={[0, 0.3, 0]} castShadow>
+        <cylinderGeometry args={[0.16, 0.22, 0.6, 10]} />
+        <meshStandardMaterial color="#FFF2D8" roughness={0.9} />
+      </mesh>
+      <mesh position={[0, 0.65, 0]} castShadow>
+        <sphereGeometry args={[0.42, 16, 12, 0, Math.PI * 2, 0, Math.PI / 2]} />
+        <meshStandardMaterial color={capColor} roughness={0.75} />
+      </mesh>
+      {DOT_OFFSETS.map((p, i) => (
+        <mesh key={i} position={p}>
+          <sphereGeometry args={[0.05, 8, 8]} />
+          <meshStandardMaterial color="#FFFFFF" />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/src/components/exhibition-gallery/models/themes/Rabbit.tsx
+++ b/src/components/exhibition-gallery/models/themes/Rabbit.tsx
@@ -1,0 +1,46 @@
+export function Rabbit(props: JSX.IntrinsicElements['group']) {
+  return (
+    <group {...props} dispose={null}>
+      <mesh position={[0, 0.22, 0]} scale={[1, 0.85, 1.3]} castShadow>
+        <sphereGeometry args={[0.2, 14, 14]} />
+        <meshStandardMaterial color="#F5F0E8" />
+      </mesh>
+      <mesh position={[0, 0.38, 0.18]} castShadow>
+        <sphereGeometry args={[0.14, 14, 14]} />
+        <meshStandardMaterial color="#F5F0E8" />
+      </mesh>
+      <mesh
+        position={[-0.07, 0.58, 0.16]}
+        rotation={[0, 0, -0.15]}
+        scale={[0.35, 1, 0.3]}
+      >
+        <sphereGeometry args={[0.12, 10, 10]} />
+        <meshStandardMaterial color="#F5F0E8" />
+      </mesh>
+      <mesh
+        position={[0.07, 0.58, 0.16]}
+        rotation={[0, 0, 0.15]}
+        scale={[0.35, 1, 0.3]}
+      >
+        <sphereGeometry args={[0.12, 10, 10]} />
+        <meshStandardMaterial color="#F5F0E8" />
+      </mesh>
+      <mesh position={[-0.05, 0.4, 0.3]}>
+        <sphereGeometry args={[0.018, 8, 8]} />
+        <meshStandardMaterial color="#222" />
+      </mesh>
+      <mesh position={[0.05, 0.4, 0.3]}>
+        <sphereGeometry args={[0.018, 8, 8]} />
+        <meshStandardMaterial color="#222" />
+      </mesh>
+      <mesh position={[0, 0.36, 0.32]}>
+        <sphereGeometry args={[0.018, 8, 8]} />
+        <meshStandardMaterial color="#F8AAB8" />
+      </mesh>
+      <mesh position={[0, 0.22, -0.22]}>
+        <sphereGeometry args={[0.07, 10, 10]} />
+        <meshStandardMaterial color="#FFFFFF" />
+      </mesh>
+    </group>
+  );
+}

--- a/src/components/exhibition-gallery/models/themes/Squirrel.tsx
+++ b/src/components/exhibition-gallery/models/themes/Squirrel.tsx
@@ -1,0 +1,38 @@
+export function Squirrel(props: JSX.IntrinsicElements['group']) {
+  return (
+    <group {...props} dispose={null}>
+      <mesh position={[0, 0.2, 0]} scale={[1, 0.9, 1.2]} castShadow>
+        <sphereGeometry args={[0.18, 14, 14]} />
+        <meshStandardMaterial color="#B8704A" />
+      </mesh>
+      <mesh position={[0, 0.34, 0.16]} castShadow>
+        <sphereGeometry args={[0.14, 14, 14]} />
+        <meshStandardMaterial color="#B8704A" />
+      </mesh>
+      <mesh position={[-0.08, 0.45, 0.16]}>
+        <coneGeometry args={[0.05, 0.1, 6]} />
+        <meshStandardMaterial color="#B8704A" />
+      </mesh>
+      <mesh position={[0.08, 0.45, 0.16]}>
+        <coneGeometry args={[0.05, 0.1, 6]} />
+        <meshStandardMaterial color="#B8704A" />
+      </mesh>
+      <mesh position={[-0.05, 0.36, 0.27]}>
+        <sphereGeometry args={[0.016, 8, 8]} />
+        <meshStandardMaterial color="#222" />
+      </mesh>
+      <mesh position={[0.05, 0.36, 0.27]}>
+        <sphereGeometry args={[0.016, 8, 8]} />
+        <meshStandardMaterial color="#222" />
+      </mesh>
+      <mesh position={[0, 0.38, -0.22]} scale={[1, 1.6, 0.7]} castShadow>
+        <sphereGeometry args={[0.16, 14, 14]} />
+        <meshStandardMaterial color="#C58860" />
+      </mesh>
+      <mesh position={[0, 0.55, -0.25]} scale={[0.8, 1, 0.6]}>
+        <sphereGeometry args={[0.13, 14, 14]} />
+        <meshStandardMaterial color="#C58860" />
+      </mesh>
+    </group>
+  );
+}

--- a/src/components/exhibition-gallery/models/themes/TreeStump.tsx
+++ b/src/components/exhibition-gallery/models/themes/TreeStump.tsx
@@ -1,0 +1,18 @@
+export function TreeStump(props: JSX.IntrinsicElements['group']) {
+  return (
+    <group {...props} dispose={null}>
+      <mesh position={[0, 0.35, 0]} castShadow>
+        <cylinderGeometry args={[0.5, 0.55, 0.7, 14]} />
+        <meshStandardMaterial color="#6B4A2A" roughness={0.95} />
+      </mesh>
+      <mesh position={[0, 0.701, 0]}>
+        <cylinderGeometry args={[0.48, 0.48, 0.02, 14]} />
+        <meshStandardMaterial color="#D4A574" roughness={0.95} />
+      </mesh>
+      <mesh position={[0, 0.711, 0]}>
+        <torusGeometry args={[0.25, 0.012, 6, 14]} />
+        <meshStandardMaterial color="#A07550" />
+      </mesh>
+    </group>
+  );
+}

--- a/src/components/exhibition-gallery/threejs/DynamicDecorations.tsx
+++ b/src/components/exhibition-gallery/threejs/DynamicDecorations.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useMemo } from 'react';
 import { Sparkles } from '@react-three/drei';
-import { GalleryPreset } from '@/types/gallery-theme';
+import { Euler, Matrix4, Quaternion, Vector3 } from 'three';
+import { GalleryPreset, ParticleConfig } from '@/types/gallery-theme';
+import { WAllType } from '@/types/gallery';
 import { MODEL_REGISTRY } from '@/lib/gallery/modelRegistry';
 import FallingPetals from './particles/FallingPetals';
 import FallingSnow from './particles/FallingSnow';
+import FallingLeaves from './particles/FallingLeaves';
 import RainDrops from './particles/RainDrops';
 
 function sr(seed: number): number {
@@ -13,6 +16,29 @@ function sr(seed: number): number {
 
 function rr(seed: number, min: number, max: number): number {
   return min + sr(seed) * (max - min);
+}
+
+type WallBox = { inv: Matrix4; halfX: number; halfZ: number };
+
+const _localPoint = new Vector3();
+
+/** (x,z) 점이 margin만큼 부풀린 벽 박스 중 하나라도 안에 들어가면 true */
+function overlapsAnyWall(
+  x: number,
+  z: number,
+  margin: number,
+  wallBoxes: WallBox[]
+): boolean {
+  for (const box of wallBoxes) {
+    _localPoint.set(x, 0, z).applyMatrix4(box.inv);
+    if (
+      Math.abs(_localPoint.x) < box.halfX + margin &&
+      Math.abs(_localPoint.z) < box.halfZ + margin
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function getCellCenters(size: number, cellSize: number): [number, number][] {
@@ -46,7 +72,8 @@ function getPositions(
   zRange?: [number, number],
   cellCenters?: [number, number][],
   cellCenterOffset = 0,
-  nearCellRadius = 2
+  nearCellRadius = 2,
+  isBlocked?: (x: number, z: number) => boolean
 ): [number, number, number][] {
   if (
     placement === 'near-cell-center' &&
@@ -103,15 +130,34 @@ function getPositions(
   const zMin = zRange ? zRange[0] : -inner;
   const zMax = zRange ? zRange[1] : inner;
 
-  return Array.from(
-    { length: count },
-    (_, i) =>
-      [
-        rr(seedOffset + i * 3, xMin, xMax),
-        rr(seedOffset + i * 3 + 10, elevationMin, elevationMax),
-        rr(seedOffset + i * 3 + 1, zMin, zMax),
-      ] as [number, number, number]
-  );
+  const spanX = xMax - xMin;
+  const spanZ = zMax - zMin;
+  const isFixedPoint = spanX < 0.01 && spanZ < 0.01;
+
+  return Array.from({ length: count }, (_, i) => {
+    let x = rr(seedOffset + i * 3, xMin, xMax);
+    let z = rr(seedOffset + i * 3 + 1, zMin, zMax);
+    // 벽과 겹치면 다시 위치를 찾는다 (벽이 없으면 첫 시도 그대로 유지)
+    if (isBlocked) {
+      for (let a = 1; a <= 12 && isBlocked(x, z); a++) {
+        if (isFixedPoint) {
+          // 고정 점(예: 가운데 나무)이 막힘 → 황금각 나선으로 주변 빈 곳 탐색
+          const r = a * 0.6;
+          const ang = a * 2.399963;
+          x = xMin + Math.cos(ang) * r;
+          z = zMin + Math.sin(ang) * r;
+        } else {
+          x = rr(seedOffset + i * 3 + a * 97, xMin, xMax);
+          z = rr(seedOffset + i * 3 + 1 + a * 97, zMin, zMax);
+        }
+      }
+    }
+    return [
+      x,
+      rr(seedOffset + i * 3 + 10, elevationMin, elevationMax),
+      z,
+    ] as [number, number, number];
+  });
 }
 
 export type CircleCollider = { x: number; z: number; radius: number };
@@ -122,6 +168,7 @@ export default function DynamicDecorations({
   height,
   cellSize = 12,
   gridSize = 1,
+  innerWalls = [],
   onColliders,
 }: {
   preset: GalleryPreset;
@@ -129,9 +176,32 @@ export default function DynamicDecorations({
   height: number;
   cellSize?: number;
   gridSize?: number;
+  innerWalls?: WAllType[];
   onColliders?: (colliders: CircleCollider[]) => void;
 }) {
   const half = size / 2;
+  // 내벽 박스를 로컬 좌표 변환용 역행렬로 미리 만들어 장식 배치 시 회피에 사용
+  const wallBoxes = useMemo<WallBox[]>(
+    () =>
+      innerWalls.map((wall) => {
+        const mat = new Matrix4().compose(
+          new Vector3(...wall.pos),
+          new Quaternion().setFromEuler(new Euler(...(wall.rot ?? [0, 0, 0]))),
+          new Vector3(1, 1, 1)
+        );
+        return {
+          inv: mat.invert(),
+          halfX: wall.boxSize[0] / 2,
+          halfZ: wall.boxSize[2] / 2,
+        };
+      }),
+    [innerWalls]
+  );
+  const particleList = preset.particles
+    ? Array.isArray(preset.particles)
+      ? preset.particles
+      : [preset.particles]
+    : [];
   const cellCenters = useMemo(
     () => getCellCenters(size, cellSize),
     [size, cellSize]
@@ -167,6 +237,14 @@ export default function DynamicDecorations({
         const offset =
           cfg.placement === 'cell-center' ? cellCenterOffsets[groupIdx] : 0;
 
+        // 모델 발자국(반경) 기준으로 벽을 피한다. 콜라이더 없는 작은 모델은 기본값 사용.
+        const footprint = (entry.colliderRadius ?? 0.4) * cfg.scaleMax;
+        const isBlocked =
+          wallBoxes.length > 0
+            ? (x: number, z: number) =>
+                overlapsAnyWall(x, z, footprint, wallBoxes)
+            : undefined;
+
         const positions = getPositions(
           cfg.placement,
           effectiveCount,
@@ -178,7 +256,8 @@ export default function DynamicDecorations({
           cfg.zRange,
           cellCenters,
           offset,
-          cfg.nearCellRadius ?? 2
+          cfg.nearCellRadius ?? 2,
+          isBlocked
         );
 
         return positions.map((pos, i) => {
@@ -210,7 +289,14 @@ export default function DynamicDecorations({
           };
         });
       }),
-    [preset.decorations, half, cellCenters, cellCenterOffsets, cellCount]
+    [
+      preset.decorations,
+      half,
+      cellCenters,
+      cellCenterOffsets,
+      cellCount,
+      wallBoxes,
+    ]
   );
 
   useEffect(() => {
@@ -234,49 +320,72 @@ export default function DynamicDecorations({
         ))
       )}
 
-      {preset.particles?.type === 'petals' && (
-        <FallingPetals
-          count={preset.particles.count}
-          size={size}
-          height={height}
-          speed={preset.particles.speed}
-        />
-      )}
-
-      {preset.particles?.type === 'rain' && (
-        <RainDrops
-          count={preset.particles.count}
-          size={size}
-          height={height}
-          speed={preset.particles.speed}
-          color={preset.particles.color}
-          opacity={preset.particles.opacity}
-        />
-      )}
-
-      {preset.particles?.type === 'snow' && (
-        <FallingSnow
-          count={preset.particles.count}
-          size={size}
-          height={height}
-          speed={preset.particles.speed}
-          color={preset.particles.color}
-          opacity={preset.particles.opacity}
-        />
-      )}
-
-      {preset.particles?.type === 'sparkles' && (
-        <Sparkles
-          count={preset.particles.count}
-          scale={[size - 1, height * 0.8, size - 1]}
-          position={[0, height * 0.4, 0]}
-          size={5}
-          speed={preset.particles.speed}
-          opacity={preset.particles.opacity}
-          color={preset.particles.color}
-          noise={0.3}
-        />
-      )}
+      {particleList.map((particle, i) => renderParticle(particle, i))}
     </>
   );
+
+  function renderParticle(particle: ParticleConfig, key: number) {
+    switch (particle.type) {
+      case 'petals':
+        return (
+          <FallingPetals
+            key={key}
+            count={particle.count}
+            size={size}
+            height={height}
+            speed={particle.speed}
+          />
+        );
+      case 'leaves':
+        return (
+          <FallingLeaves
+            key={key}
+            count={particle.count}
+            size={size}
+            height={height}
+            speed={particle.speed}
+          />
+        );
+      case 'rain':
+        return (
+          <RainDrops
+            key={key}
+            count={particle.count}
+            size={size}
+            height={height}
+            speed={particle.speed}
+            color={particle.color}
+            opacity={particle.opacity}
+          />
+        );
+      case 'snow':
+        return (
+          <FallingSnow
+            key={key}
+            count={particle.count}
+            size={size}
+            height={height}
+            speed={particle.speed}
+            color={particle.color}
+            opacity={particle.opacity}
+          />
+        );
+      case 'sparkles':
+        return (
+          <Sparkles
+            key={key}
+            count={particle.count}
+            scale={[size - 1, height * 0.8, size - 1]}
+            position={[0, height * 0.4, 0]}
+            size={5}
+            speed={particle.speed}
+            opacity={particle.opacity}
+            color={particle.color}
+            noise={0.3}
+          />
+        );
+      default:
+        return null;
+    }
+  }
 }

--- a/src/components/exhibition-gallery/threejs/DynamicFloor.tsx
+++ b/src/components/exhibition-gallery/threejs/DynamicFloor.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useTexture } from '@react-three/drei';
 import { MeshReflectorMaterial } from '@react-three/drei';
 import { RepeatWrapping } from 'three';
 import { FloorConfig } from '@/types/gallery-theme';
+import { FLOOR_PATTERNS } from '@/lib/gallery/floorPatterns';
 
 export default function DynamicFloor({
   size,
@@ -11,34 +12,64 @@ export default function DynamicFloor({
   size: number;
   config: FloorConfig;
 }) {
-  const texture = useTexture('/gallery/floor.jpg');
+  const spec = config.pattern ? FLOOR_PATTERNS[config.pattern] : undefined;
 
-  const cloned = useMemo(() => {
-    const t = texture.clone();
+  // useTexture는 hook 규칙상 항상 호출해야 한다. 이미지 패턴이 아니어도
+  // 기본 경로를 로드(url 기준 캐시되어 저렴)하고, map 계산에서는 사용하지 않는다.
+  const imageUrl =
+    spec?.source.type === 'image' ? spec.source.url : '/gallery/floor.jpg';
+  const texture = useTexture(imageUrl);
+
+  const map = useMemo(() => {
+    if (!spec) return null;
+    const t =
+      spec.source.type === 'image'
+        ? texture.clone()
+        : spec.source.generator(config.color);
+    if (!t) return null;
     t.wrapS = RepeatWrapping;
     t.wrapT = RepeatWrapping;
-    t.repeat.set(size / 8, size / 8);
+    t.repeat.set(size / spec.repeatDivisor, size / spec.repeatDivisor);
     t.needsUpdate = true;
     return t;
-  }, [texture, size]);
+  }, [spec, texture, size, config.color]);
+
+  useEffect(() => {
+    // 절차 생성 텍스처만 정리한다. (이미지는 useTexture 캐시를 공유)
+    if (spec?.source.type !== 'procedural') return;
+    return () => {
+      map?.dispose();
+    };
+  }, [map, spec]);
+
+  const materialColor = spec?.tintWhite ? '#FFFFFF' : config.color;
 
   return (
     <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
       <planeGeometry args={[size, size]} />
-      <MeshReflectorMaterial
-        map={config.useTexture ? cloned : null}
-        color={config.color}
-        blur={config.blur as [number, number]}
-        resolution={512}
-        mixBlur={config.useTexture ? 0.8 : 1.0}
-        mixStrength={config.useTexture ? 1 : 1.2}
-        roughness={config.roughness}
-        depthScale={0.5}
-        minDepthThreshold={0.4}
-        maxDepthThreshold={1.0}
-        metalness={config.metalness}
-        mirror={config.mirror}
-      />
+      {spec?.reflective === false ? (
+        <meshStandardMaterial
+          map={map}
+          color={materialColor}
+          roughness={config.roughness}
+          metalness={config.metalness}
+        />
+      ) : (
+        <MeshReflectorMaterial
+          map={map}
+          color={materialColor}
+          blur={config.blur as [number, number]}
+          resolution={512}
+          mixBlur={spec?.mixBlur ?? 1.0}
+          mixStrength={spec?.mixStrength ?? 1.2}
+          roughness={config.roughness}
+          depthScale={0.5}
+          minDepthThreshold={0.4}
+          maxDepthThreshold={1.0}
+          metalness={config.metalness}
+          mirror={config.mirror}
+        />
+      )}
     </mesh>
   );
 }

--- a/src/components/exhibition-gallery/threejs/InnerWall.tsx
+++ b/src/components/exhibition-gallery/threejs/InnerWall.tsx
@@ -9,12 +9,14 @@ export default function InnerWalls({
   walls,
   paintingRefs,
   htmlRefs,
+  wallTexture = null,
 }: {
   paintingTextures: Texture[];
   init: GalleryUIArtworkProps[];
   walls: WAllType[];
   paintingRefs: React.RefObject<(Group | null)[]>;
   htmlRefs: React.RefObject<(HTMLDivElement | null)[]>;
+  wallTexture?: Texture | null;
 }) {
   let interiorBackIdx = walls.length;
   const assignments = walls.map((wall, i) => ({
@@ -34,7 +36,8 @@ export default function InnerWalls({
             <mesh castShadow receiveShadow>
               <boxGeometry args={[w, wallH, d]} />
               <meshStandardMaterial
-                color={wall.color}
+                color={wallTexture ? '#FFFFFF' : wall.color}
+                map={wallTexture ?? undefined}
                 roughness={0.85}
                 metalness={0.02}
               />

--- a/src/components/exhibition-gallery/threejs/Room.tsx
+++ b/src/components/exhibition-gallery/threejs/Room.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTexture } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
-import { Group, Quaternion, Vector3 } from 'three';
+import { Group, Quaternion, RepeatWrapping, Vector3 } from 'three';
 import { likesToggle } from '@/lib/artwork/service';
 import { downloadImgHandler } from '@/lib/gallery/image';
 
 import { User } from '@supabase/supabase-js';
 import { useRouter } from 'next/navigation';
 import { GalleryUIArtworkProps, WAllType } from '@/types/gallery';
-import { FloorConfig } from '@/types/gallery-theme';
+import { FloorConfig, WallPatternConfig } from '@/types/gallery-theme';
+import { WALL_PATTERNS } from '@/lib/gallery/wallPatterns';
 import { defaultPreset } from '@/lib/gallery/presets';
 import InnerWalls from '@/components/exhibition-gallery/threejs/InnerWall';
 import Walls from '@/components/exhibition-gallery/threejs/Walls';
@@ -22,6 +23,8 @@ export default function Room({
   exhibitionId,
   user,
   floorConfig = defaultPreset.floor,
+  wallColor = defaultPreset.wallColor,
+  wallPattern,
 }: {
   init: GalleryUIArtworkProps[];
   size: number;
@@ -31,11 +34,34 @@ export default function Room({
   exhibitionId: string;
   user: User | null;
   floorConfig?: FloorConfig;
+  wallColor?: string;
+  wallPattern?: WallPatternConfig;
 }) {
   const [artworks, setArtworks] = useState(init);
   const loadingRef = useRef(false);
   const urls = useMemo(() => artworks.map((x) => x.image_url), [artworks]);
   const paintingTextures = useTexture(urls);
+
+  // 벽 패턴 텍스처는 한 번만 생성해 외벽/내벽이 공유한다.
+  const wallTexture = useMemo(() => {
+    if (!wallPattern) return null;
+    const spec = WALL_PATTERNS[wallPattern.pattern];
+    if (!spec) return null;
+    const t = spec.generator(wallPattern.baseColor ?? wallColor);
+    if (!t) return null;
+    const [rx, ry] = wallPattern.repeat ?? spec.defaultRepeat;
+    t.wrapS = RepeatWrapping;
+    t.wrapT = RepeatWrapping;
+    t.repeat.set(rx, ry);
+    t.needsUpdate = true;
+    return t;
+  }, [wallPattern, wallColor]);
+
+  useEffect(() => {
+    return () => {
+      wallTexture?.dispose();
+    };
+  }, [wallTexture]);
 
   const paintingRefs = useRef<(Group | null)[]>([]);
   const htmlRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -180,7 +206,7 @@ export default function Room({
   return (
     <>
       <DynamicFloor size={size} config={floorConfig} />
-      <Walls walls={walls} />
+      <Walls walls={walls} wallTexture={wallTexture} />
 
       <InnerWalls
         walls={innerWalls}
@@ -188,6 +214,7 @@ export default function Room({
         paintingTextures={paintingTextures}
         paintingRefs={paintingRefs}
         htmlRefs={htmlRefs}
+        wallTexture={wallTexture}
       />
     </>
   );

--- a/src/components/exhibition-gallery/threejs/Scene.tsx
+++ b/src/components/exhibition-gallery/threejs/Scene.tsx
@@ -192,6 +192,8 @@ export default function Scene2({
         innerWalls={innerWalls}
         init={init}
         floorConfig={preset.floor}
+        wallColor={preset.wallColor}
+        wallPattern={preset.wallPattern}
       />
       <DynamicDecorations
         preset={preset}
@@ -199,6 +201,7 @@ export default function Scene2({
         height={height}
         cellSize={cellSize}
         gridSize={gridSize}
+        innerWalls={innerWalls}
         onColliders={handleColliders}
       />
       <Player

--- a/src/components/exhibition-gallery/threejs/Walls.tsx
+++ b/src/components/exhibition-gallery/threejs/Walls.tsx
@@ -1,6 +1,13 @@
+import { Texture } from 'three';
 import { WAllType } from '@/types/gallery';
 
-export default function Walls({ walls }: { walls: WAllType[] }) {
+export default function Walls({
+  walls,
+  wallTexture = null,
+}: {
+  walls: WAllType[];
+  wallTexture?: Texture | null;
+}) {
   return (
     <>
       {walls.map((wall, i) => {
@@ -10,6 +17,7 @@ export default function Walls({ walls }: { walls: WAllType[] }) {
               <boxGeometry args={wall.boxSize} />
               <meshStandardMaterial
                 color={wall.color}
+                map={wallTexture ?? undefined}
                 roughness={0.85}
                 metalness={0.02}
               />

--- a/src/components/exhibition-gallery/threejs/particles/FallingLeaves.tsx
+++ b/src/components/exhibition-gallery/threejs/particles/FallingLeaves.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import {
+  DoubleSide,
+  Group,
+  MeshStandardMaterial,
+  Shape,
+  ShapeGeometry,
+} from 'three';
+
+function sr(seed: number): number {
+  const x = Math.sin(seed + 1) * 10000;
+  return x - Math.floor(x);
+}
+
+function rr(seed: number, min: number, max: number): number {
+  return min + sr(seed) * (max - min);
+}
+
+/** 초록 → 단풍(갈색/주황) 잎 색 팔레트 */
+const LEAF_COLORS = ['#6BA34A', '#4F8C3A', '#C9882E', '#B5651D', '#D9A441'];
+
+type LeafState = {
+  x: number;
+  z: number;
+  startY: number;
+  speed: number;
+  driftX: number;
+  driftZ: number;
+  rotSpeed: number;
+  scale: number;
+  initialRotY: number;
+  colorIndex: number;
+};
+
+function SingleLeaf({
+  state,
+  height,
+  geometry,
+  material,
+}: {
+  state: LeafState;
+  height: number;
+  geometry: ShapeGeometry;
+  material: MeshStandardMaterial;
+}) {
+  const ref = useRef<Group>(null);
+  const y = useRef(state.startY);
+  const rotY = useRef(state.initialRotY);
+
+  useFrame((_, delta) => {
+    if (!ref.current) return;
+    y.current -= state.speed * delta;
+    rotY.current += state.rotSpeed * delta;
+
+    if (y.current < -0.5) y.current = height + rr(y.current * 1000, 0, height);
+
+    ref.current.position.x = state.x + Math.sin(y.current * 0.5) * state.driftX;
+    ref.current.position.y = y.current;
+    ref.current.position.z = state.z + Math.cos(y.current * 0.4) * state.driftZ;
+    ref.current.rotation.y = rotY.current;
+    ref.current.rotation.x = Math.sin(y.current * 0.7) * 0.6;
+    ref.current.rotation.z = Math.cos(y.current * 0.5) * 0.4;
+  });
+
+  return (
+    <group ref={ref} scale={state.scale}>
+      <mesh geometry={geometry} material={material} castShadow />
+    </group>
+  );
+}
+
+export default function FallingLeaves({
+  count = 40,
+  size,
+  height,
+  speed = 1.0,
+}: {
+  count?: number;
+  size: number;
+  height: number;
+  speed?: number;
+}) {
+  const half = size / 2 - 0.5;
+
+  const geometry = useMemo(() => {
+    const shape = new Shape();
+    shape.moveTo(0, -0.5);
+    shape.bezierCurveTo(0.45, -0.2, 0.4, 0.35, 0, 0.6);
+    shape.bezierCurveTo(-0.4, 0.35, -0.45, -0.2, 0, -0.5);
+    const geo = new ShapeGeometry(shape);
+    geo.center();
+    return geo;
+  }, []);
+
+  const materials = useMemo(
+    () =>
+      LEAF_COLORS.map(
+        (color) =>
+          new MeshStandardMaterial({
+            color,
+            side: DoubleSide,
+            roughness: 0.85,
+          })
+      ),
+    []
+  );
+
+  useEffect(
+    () => () => {
+      geometry.dispose();
+      materials.forEach((m) => m.dispose());
+    },
+    [geometry, materials]
+  );
+
+  const leaves = useMemo(
+    () =>
+      Array.from({ length: count }, (_, i) => ({
+        x: rr(i * 7, -half, half),
+        z: rr(i * 7 + 1, -half, half),
+        startY: rr(i * 7 + 2, 0, height),
+        speed: speed * rr(i * 7 + 3, 0.5, 1.2),
+        driftX: rr(i * 7 + 4, 0.4, 1.0),
+        driftZ: rr(i * 7 + 5, 0.4, 1.0),
+        rotSpeed: rr(i * 7 + 6, 0.6, 2.2),
+        scale: rr(i * 7 + 7, 0.25, 0.5),
+        initialRotY: rr(i * 7 + 8, 0, Math.PI * 2),
+        colorIndex: Math.floor(sr(i * 7 + 9) * LEAF_COLORS.length),
+      })),
+    [count, half, height, speed]
+  );
+
+  return (
+    <>
+      {leaves.map((state, i) => (
+        <SingleLeaf
+          key={i}
+          state={state}
+          height={height}
+          geometry={geometry}
+          material={materials[state.colorIndex]}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/lib/gallery/floorPatterns.ts
+++ b/src/lib/gallery/floorPatterns.ts
@@ -1,0 +1,40 @@
+import { Texture } from 'three';
+import { createGrassTexture } from '@/lib/gallery/textures';
+
+type FloorPatternSource =
+  | { type: 'image'; url: string }
+  | { type: 'procedural'; generator: (color: string) => Texture | null };
+
+export type FloorPatternSpec = {
+  source: FloorPatternSource;
+  /** 텍스처 반복 횟수 = size / repeatDivisor */
+  repeatDivisor: number;
+  mixBlur: number;
+  mixStrength: number;
+  /** 텍스처 원색을 그대로 살릴 때 true (재질 color를 흰색으로 둠) */
+  tintWhite?: boolean;
+  /** false면 거울 반사 없는 일반 머티리얼로 렌더. 미지정 시 반사 사용 */
+  reflective?: boolean;
+};
+
+/**
+ * 바닥 패턴 레지스트리.
+ * 새 패턴을 추가할 때는 여기에 한 줄만 등록하면 되고,
+ * DynamicFloor 본체는 수정할 필요가 없다.
+ */
+export const FLOOR_PATTERNS: Record<string, FloorPatternSpec> = {
+  wood: {
+    source: { type: 'image', url: '/gallery/floor.jpg' },
+    repeatDivisor: 8,
+    mixBlur: 0.8,
+    mixStrength: 1,
+  },
+  grass: {
+    source: { type: 'procedural', generator: createGrassTexture },
+    repeatDivisor: 4,
+    mixBlur: 1,
+    mixStrength: 1,
+    tintWhite: true,
+    reflective: false,
+  },
+};

--- a/src/lib/gallery/modelRegistry.ts
+++ b/src/lib/gallery/modelRegistry.ts
@@ -26,6 +26,10 @@ import { TreeDecoratedSnow } from '@/components/exhibition-gallery/models/basic/
 import { WreathDecorated } from '@/components/exhibition-gallery/models/basic/WreathDecorated';
 import { FlowerTreeA } from '@/components/exhibition-gallery/models/basic/FlowerTreeA';
 import { FlowerTreeB } from '@/components/exhibition-gallery/models/basic/FlowerTreeB';
+import { TreeStump } from '@/components/exhibition-gallery/models/themes/TreeStump';
+import { Mushroom } from '@/components/exhibition-gallery/models/themes/Mushroom';
+import { Rabbit } from '@/components/exhibition-gallery/models/themes/Rabbit';
+import { Squirrel } from '@/components/exhibition-gallery/models/themes/Squirrel';
 
 export type ModelEntry = {
   component: React.ComponentType<JSX.IntrinsicElements['group']>;
@@ -90,4 +94,13 @@ export const MODEL_REGISTRY: Record<string, ModelEntry> = {
     yOffset: 0,
     colliderRadius: 0.9,
   },
+  TreeStump: {
+    component: TreeStump,
+    baseScale: 1.0,
+    yOffset: 0,
+    colliderRadius: 0.55,
+  },
+  Mushroom: { component: Mushroom, baseScale: 1.0, yOffset: 0 },
+  Rabbit: { component: Rabbit, baseScale: 1.0, yOffset: 0 },
+  Squirrel: { component: Squirrel, baseScale: 1.0, yOffset: 0 },
 };

--- a/src/lib/gallery/presets.ts
+++ b/src/lib/gallery/presets.ts
@@ -28,6 +28,10 @@ export const MODEL_REGISTRY_KEYS = [
   'WreathDecorated',
   'FlowerTreeA',
   'FlowerTreeB',
+  'TreeStump',
+  'Mushroom',
+  'Rabbit',
+  'Squirrel',
 ] as const;
 
 export const defaultPreset: GalleryPreset = {
@@ -57,7 +61,7 @@ export const defaultPreset: GalleryPreset = {
     metalness: 0.05,
     mirror: 0,
     blur: [300, 100],
-    useTexture: true,
+    pattern: 'wood',
   },
   wallColor: '#ffffff',
   decorations: [],
@@ -93,7 +97,6 @@ export const christmasPreset: GalleryPreset = {
     metalness: 0.0,
     mirror: 0.15,
     blur: [1000, 500],
-    useTexture: false,
   },
   wallColor: '#d4eeff',
   decorations: [
@@ -154,7 +157,6 @@ export const aiPresetSpace: GalleryPreset = {
     metalness: 0.15,
     mirror: 0.5,
     blur: [800, 400],
-    useTexture: false,
   },
   wallColor: '#0d0d1a',
   decorations: [
@@ -224,7 +226,6 @@ export const aiPresetVoyage: GalleryPreset = {
     metalness: 0.1,
     mirror: 0.4,
     blur: [600, 200],
-    useTexture: false,
   },
   wallColor: '#a0d4f0',
   decorations: [
@@ -297,7 +298,7 @@ export const aiPresetBlossom: GalleryPreset = {
     metalness: 0.03,
     mirror: 0.08,
     blur: [300, 100],
-    useTexture: true,
+    pattern: 'wood',
   },
   wallColor: '#fff0f5',
   decorations: [
@@ -368,7 +369,6 @@ export const aiPresetWinter: GalleryPreset = {
     metalness: 0.0,
     mirror: 0.15,
     blur: [1000, 500],
-    useTexture: false,
   },
   wallColor: '#e8f4ff',
   decorations: [
@@ -432,7 +432,6 @@ export const aiPresetRainy: GalleryPreset = {
     metalness: 0.05,
     mirror: 0.4,
     blur: [600, 300],
-    useTexture: false,
   },
   wallColor: '#c8d0d8',
   decorations: [
@@ -476,4 +475,113 @@ export const aiPresetRainy: GalleryPreset = {
     speed: 9.0,
     opacity: 0.5,
   },
+};
+
+/** 숲속(forest) 테마 프리셋. */
+export const forestPreset: GalleryPreset = {
+  id: 'forest',
+  atmosphere: {
+    type: 'sky',
+    sunPosition: [20, 12, 20],
+    turbidity: 8,
+    rayleigh: 2,
+    mieCoefficient: 0.005,
+    mieDirectionalG: 0.9,
+    clouds: true,
+  },
+  lighting: {
+    hemisphere: ['#FFF0DC', '#A8C870', 1.0],
+    ambient: { color: '#FFE8C8', intensity: 0.7 },
+    directional: { position: [20, 20, 25], color: '#FFD080', intensity: 1.2 },
+    toneMappingExposure: 1.2,
+  },
+  floor: {
+    color: '#9DC872',
+    roughness: 0.95,
+    metalness: 0,
+    mirror: 0,
+    blur: [300, 100],
+    pattern: 'grass',
+  },
+  wallColor: '#D8ECC0',
+  wallPattern: {
+    pattern: 'flower',
+    baseColor: '#D8ECC0',
+    repeat: [3, 1.5],
+  },
+  ceiling: {
+    type: 'fairy-lights',
+    planeColor: '#FFF8E8',
+    bulbColors: ['#FFE070', '#FFD040', '#FFE890', '#FFC050'],
+    strandCount: 2,
+  },
+  decorations: [
+    {
+      model: 'TreeC',
+      count: 1,
+      placement: 'scattered',
+      scaleMin: 1.0,
+      scaleMax: 1.0,
+      xRange: [0, 0],
+      zRange: [0, 0],
+    },
+    {
+      model: 'TreeStump',
+      count: 3,
+      placement: 'scattered',
+      scaleMin: 1.1,
+      scaleMax: 1.5,
+    },
+    {
+      model: 'Mushroom',
+      count: 8,
+      placement: 'scattered',
+      scaleMin: 0.7,
+      scaleMax: 1.3,
+    },
+    {
+      model: 'FlowerB',
+      count: 5,
+      placement: 'scattered',
+      scaleMin: 0.5,
+      scaleMax: 0.9,
+    },
+    {
+      model: 'FlowerC',
+      count: 4,
+      placement: 'scattered',
+      scaleMin: 0.5,
+      scaleMax: 0.9,
+    },
+    {
+      model: 'RockA',
+      count: 3,
+      placement: 'scattered',
+      scaleMin: 0.5,
+      scaleMax: 0.9,
+    },
+    {
+      model: 'Rabbit',
+      count: 2,
+      placement: 'scattered',
+      scaleMin: 0.9,
+      scaleMax: 1.1,
+    },
+    {
+      model: 'Squirrel',
+      count: 2,
+      placement: 'scattered',
+      scaleMin: 0.9,
+      scaleMax: 1.1,
+    },
+  ],
+  particles: [
+    {
+      type: 'leaves',
+      color: '#6BA34A',
+      count: 35,
+      speed: 0.8,
+      opacity: 1,
+    },
+  ],
 };

--- a/src/lib/gallery/server.ts
+++ b/src/lib/gallery/server.ts
@@ -47,16 +47,17 @@ Analyze the provided image and return a GalleryPreset JSON that matches its mood
 
 ## FLOOR
 - floor.color, floor.roughness(0.2~0.9), floor.metalness(0~0.2), floor.mirror(0~0.5)
-- floor.blur([x,y]), floor.useTexture(true=wood texture, false=solid color)
+- floor.blur([x,y]), floor.pattern("wood"=wood texture | "grass"=grass texture | omit=solid color)
 
   Presets by theme:
-  - Natural/wood:  { color:"#ffffff", roughness:0.7,  metalness:0.05, mirror:0,    blur:[300,100],  useTexture:true  }
-  - Ocean:         { color:"#0a3d62", roughness:0.3,  metalness:0.1,  mirror:0.4,  blur:[600,200],  useTexture:false }
-  - Winter:        { color:"#d4eeff", roughness:0.5,  metalness:0.0,  mirror:0.15, blur:[1000,500], useTexture:false }
-  - Space:         { color:"#0d0d1a", roughness:0.2,  metalness:0.15, mirror:0.5,  blur:[800,400],  useTexture:false }
-  - Spring/flower: { color:"#fff5f8", roughness:0.65, metalness:0.03, mirror:0.08, blur:[300,100],  useTexture:true  }
-  - Warm/cozy:     { color:"#fdf0e0", roughness:0.75, metalness:0.02, mirror:0.05, blur:[300,100],  useTexture:true  }
-  - Rain/overcast: { color:"#b0bec5", roughness:0.3,  metalness:0.05, mirror:0.4,  blur:[600,300],  useTexture:false }
+  - Natural/wood:  { color:"#ffffff", roughness:0.7,  metalness:0.05, mirror:0,    blur:[300,100],  pattern:"wood" }
+  - Ocean:         { color:"#0a3d62", roughness:0.3,  metalness:0.1,  mirror:0.4,  blur:[600,200]  }
+  - Winter:        { color:"#d4eeff", roughness:0.5,  metalness:0.0,  mirror:0.15, blur:[1000,500] }
+  - Space:         { color:"#0d0d1a", roughness:0.2,  metalness:0.15, mirror:0.5,  blur:[800,400]  }
+  - Spring/flower: { color:"#fff5f8", roughness:0.65, metalness:0.03, mirror:0.08, blur:[300,100],  pattern:"wood" }
+  - Warm/cozy:     { color:"#fdf0e0", roughness:0.75, metalness:0.02, mirror:0.05, blur:[300,100],  pattern:"wood" }
+  - Rain/overcast: { color:"#b0bec5", roughness:0.3,  metalness:0.05, mirror:0.4,  blur:[600,300]  }
+  - Forest/grass:  { color:"#9DC872", roughness:0.95, metalness:0, mirror:0, blur:[300,100], pattern:"grass" }
 
 ## DECORATION PLACEMENT & SCALE
 - placement:
@@ -115,7 +116,7 @@ Analyze the provided image and return a GalleryPreset JSON that matches its mood
 - rain: count 150~300, speed 7~12, color #a8cfe0~#8ab4c8, opacity 0.4~0.6
 
 ## OUTPUT SCHEMA
-{"id":"<slug>","atmosphere":<atmosphere>,"lighting":{"hemisphere":["#rrggbb","#rrggbb",0.0],"ambient":{"color":"#rrggbb","intensity":0.0},"directional":{"position":[0,0,0],"color":"#rrggbb","intensity":0.0},"toneMappingExposure":0.0},"floor":{"color":"#rrggbb","roughness":0.0,"metalness":0.0,"mirror":0.0,"blur":[0,0],"useTexture":true},"wallColor":"#rrggbb","decorations":[{"model":"<ModelName>","count":0,"countPerCell":0,"placement":"scattered","nearCellRadius":0.0,"scaleMin":0.0,"scaleMax":0.0,"color":"#rrggbb","elevationMin":0.0,"elevationMax":0.0}],"particles":{"type":"sparkles","color":"#rrggbb","count":0,"speed":0.0,"opacity":0.0}}
+{"id":"<slug>","atmosphere":<atmosphere>,"lighting":{"hemisphere":["#rrggbb","#rrggbb",0.0],"ambient":{"color":"#rrggbb","intensity":0.0},"directional":{"position":[0,0,0],"color":"#rrggbb","intensity":0.0},"toneMappingExposure":0.0},"floor":{"color":"#rrggbb","roughness":0.0,"metalness":0.0,"mirror":0.0,"blur":[0,0],"pattern":"wood"},"wallColor":"#rrggbb","decorations":[{"model":"<ModelName>","count":0,"countPerCell":0,"placement":"scattered","nearCellRadius":0.0,"scaleMin":0.0,"scaleMax":0.0,"color":"#rrggbb","elevationMin":0.0,"elevationMax":0.0}],"particles":{"type":"sparkles","color":"#rrggbb","count":0,"speed":0.0,"opacity":0.0}}
 
 ## REFERENCE EXAMPLE
 ${JSON.stringify(defaultPreset)}`;

--- a/src/lib/gallery/textures.ts
+++ b/src/lib/gallery/textures.ts
@@ -1,0 +1,80 @@
+import { CanvasTexture, RepeatWrapping, Texture } from 'three';
+
+export function createFlowerPatternTexture(
+  baseColor = '#D8ECC0'
+): Texture | null {
+  if (typeof document === 'undefined') return null;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 256;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+
+  ctx.fillStyle = baseColor;
+  ctx.fillRect(0, 0, 256, 256);
+
+  const flowers = [
+    { x: 40, y: 50, color: '#F8C8D8' },
+    { x: 170, y: 90, color: '#FFE0A0' },
+    { x: 90, y: 180, color: '#E0C8F0' },
+    { x: 210, y: 210, color: '#F8D8E8' },
+    { x: 130, y: 130, color: '#FFFFFF' },
+    { x: 60, y: 220, color: '#FFD5B0' },
+    { x: 230, y: 50, color: '#F8C8D8' },
+  ];
+
+  for (const f of flowers) {
+    ctx.fillStyle = f.color;
+    for (let p = 0; p < 5; p++) {
+      const a = (p / 5) * Math.PI * 2;
+      ctx.beginPath();
+      ctx.arc(
+        f.x + Math.cos(a) * 8,
+        f.y + Math.sin(a) * 8,
+        6,
+        0,
+        Math.PI * 2
+      );
+      ctx.fill();
+    }
+    ctx.fillStyle = '#FFE060';
+    ctx.beginPath();
+    ctx.arc(f.x, f.y, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const tex = new CanvasTexture(canvas);
+  tex.wrapS = tex.wrapT = RepeatWrapping;
+  return tex;
+}
+
+export function createGrassTexture(baseColor = '#9DC872'): Texture | null {
+  if (typeof document === 'undefined') return null;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 256;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+
+  ctx.fillStyle = baseColor;
+  ctx.fillRect(0, 0, 256, 256);
+
+  for (let i = 0; i < 400; i++) {
+    const x = Math.random() * 256;
+    const y = Math.random() * 256;
+    const len = 3 + Math.random() * 5;
+    const greens = ['#7AAE58', '#88B860', '#A5D080', '#6B9E48'];
+    ctx.strokeStyle = greens[Math.floor(Math.random() * greens.length)];
+    ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.lineTo(x + (Math.random() - 0.5) * 2, y - len);
+    ctx.stroke();
+  }
+
+  const tex = new CanvasTexture(canvas);
+  tex.wrapS = tex.wrapT = RepeatWrapping;
+  return tex;
+}

--- a/src/lib/gallery/wallPatterns.ts
+++ b/src/lib/gallery/wallPatterns.ts
@@ -1,0 +1,21 @@
+import { Texture } from 'three';
+import { createFlowerPatternTexture } from '@/lib/gallery/textures';
+
+export type WallPatternSpec = {
+  /** baseColor를 받아 절차적으로 텍스처를 생성 */
+  generator: (baseColor: string) => Texture | null;
+  /** wallPattern.repeat 미지정 시 사용할 기본 반복 [x, y] */
+  defaultRepeat: [number, number];
+};
+
+/**
+ * 벽 패턴 레지스트리.
+ * 새 패턴을 추가할 때는 여기에 한 줄만 등록하면 되고,
+ * Walls / InnerWalls 본체는 수정할 필요가 없다.
+ */
+export const WALL_PATTERNS: Record<string, WallPatternSpec> = {
+  flower: {
+    generator: createFlowerPatternTexture,
+    defaultRepeat: [3, 1.5],
+  },
+};

--- a/src/types/gallery-theme.ts
+++ b/src/types/gallery-theme.ts
@@ -58,7 +58,7 @@ export type DecorationConfig = {
 };
 
 export type ParticleConfig = {
-  type: 'sparkles' | 'snow' | 'petals' | 'rain';
+  type: 'sparkles' | 'snow' | 'petals' | 'rain' | 'leaves';
   color: string;
   count: number;
   speed: number;
@@ -71,8 +71,33 @@ export type FloorConfig = {
   metalness: number;
   mirror: number;
   blur: number[];
-  useTexture: boolean;
+  /** FLOOR_PATTERNS의 키('wood' | 'grass' 등). 미지정 시 텍스처 없는 단색 바닥 */
+  pattern?: string;
 };
+
+export type WallPatternConfig = {
+  /** WALL_PATTERNS의 키('flower' 등) */
+  pattern: string;
+  /** 미지정 시 GalleryPreset.wallColor 사용 */
+  baseColor?: string;
+  /** 미지정 시 레지스트리의 defaultRepeat */
+  repeat?: [number, number];
+};
+
+export type FlatCeilingConfig = {
+  type: 'flat';
+  color?: string;
+};
+
+export type FairyLightsCeilingConfig = {
+  type: 'fairy-lights';
+  planeColor?: string;
+  bulbColors?: string[];
+  /** 천장에 늘어뜨릴 알전구 줄 개수. 미지정 시 2 */
+  strandCount?: number;
+};
+
+export type CeilingConfig = FlatCeilingConfig | FairyLightsCeilingConfig;
 
 export type GalleryPreset = {
   id: string;
@@ -80,6 +105,9 @@ export type GalleryPreset = {
   lighting: LightingConfig;
   floor: FloorConfig;
   wallColor: string;
+  wallPattern?: WallPatternConfig;
+  ceiling?: CeilingConfig;
   decorations: DecorationConfig[];
-  particles?: ParticleConfig;
+  /** 단일 입자 또는 여러 입자 동시 적용(예: forest = 반짝이 + 나뭇잎) */
+  particles?: ParticleConfig | ParticleConfig[];
 };


### PR DESCRIPTION
## 📌 개요

전시관에 **forest(숲속) 테마**를 추가했습니다.
기존 프리셋 기반에서 부족한 부분만 **optional 필드로 확장**해 구현했습니다. 
다른 테마(default/christmas/space/ocean 등) 동작은 변하지 않습니다.

  ## 🔍 변경 사항

- **숲 장식 모델 4종 추가** (`models/themes/`): TreeStump / Mushroom / Rabbit / Squirrel → `MODEL_REGISTRY`에 등록(baseScale·yOffset·colliderRadius)
- **바닥/벽 패턴 시스템** 추가
- `floorPatterns.ts`(grass) / `wallPatterns.ts`(flower) 레지스트리 + 절차 텍스처(`textures.ts`)
- `floor.useTexture(boolean)` → `floor.pattern(string)`으로 스키마 변경
- grass 바닥은 거울 반사 제거(일반 머티리얼) — 반사 패스 비용도 절감
- **떨어지는 나뭇잎 입자**(`FallingLeaves.tsx`) 추가 + `particles` 배열 지원
- **forestPreset 정의**: 잔디 바닥 + 꽃무늬 벽 + 알전구 천장, 가운데 나무 1그루 + 그루터기/버섯/들꽃/바위/토끼/다람쥐
- **장식물 벽 회피**(`DynamicDecorations`): 내벽을 전달받아 배치 시 벽과 겹치면 빈 곳으로 재배치(가운데 고정 장식은 나선 탐색)
- AI 프리셋 생성 프롬프트(`server.ts`)에 grass/pattern 및 Forest 예시 반영
  
  ## 🔗 관련 이슈 번호
  
  - close #148 

  ## 📸 스크린샷 (UI 변경 시 필수)

<img width="3024" height="1650" alt="image" src="https://github.com/user-attachments/assets/20196436-84ff-4153-93d5-20de373bf862" />


  ## 🧪 테스트 결과
  
  - [x] 코드가 정상 작동하는 지 확인했나요?
  - [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
  - [x] 라우팅이 정상 작동하는 지 확인했나요?
  - [x] 빌드 시 오류가 발생하는 지 확인했나요? (`tsc --noEmit`
  통과)
  
  ## 🚩 기타 참고 사항
 - **이 PR의 base는 `feat#147`입니다.** forest는 feat#147의 프리셋 갤러리 시스템 위에 쌓인 작업이라, 기반이 있는 feat#147을 base로 잡았습니다. → feat#147이 main에 머지된 뒤 base를 main으로 변경해 머지하면 됩니다.
- `floor.useTexture(boolean)` → `floor.pattern(string)` 스키마 변경이 포함됩니다. DB에 저장된 기존 프리셋에 `useTexture`가 있다면 호환 확인이 필요합니다.
- 모든 확장 필드(`floor.pattern`, `wallPattern`, `ceiling`, `particles` 배열)는 optional이라 다른 테마는 현행 동작 그대로입니다.