### PR TITLE
[PR] Image2Video 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.100.1",
         "@base-ui/react": "^1.4.1",
+        "@fal-ai/client": "^1.10.1",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.0",
         "@supabase/ssr": "^0.10.2",
@@ -936,6 +937,29 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fal-ai/client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@fal-ai/client/-/client-1.10.1.tgz",
+      "integrity": "sha512-c3AVeH31OioiI2J1BfW8Cryi1DhUYldnY3X35nv6xLMq3fU2NQOo+eYaR5mL2O8MoHHh+HzXdQuIyanIyeq+ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^3.0.0-beta2",
+        "eventsource-parser": "^1.1.2",
+        "robot3": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@fal-ai/client/node_modules/eventsource-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -1723,6 +1747,15 @@
       },
       "peerDependencies": {
         "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -8899,6 +8932,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robot3": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/robot3/-/robot3-0.4.1.tgz",
+      "integrity": "sha512-hzjy826lrxzx8eRgv80idkf8ua1JAepRc9Efdtj03N3KNJuznQCPlyCJ7gnUmDFwZCLQjxy567mQVKmdv2BsXQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/router": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.100.1",
     "@base-ui/react": "^1.4.1",
+    "@fal-ai/client": "^1.10.1",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.0",
     "@supabase/ssr": "^0.10.2",

--- a/src/app/(exhibitions)/exhibitions/[id]/page.tsx
+++ b/src/app/(exhibitions)/exhibitions/[id]/page.tsx
@@ -123,11 +123,13 @@ export default async function ExhibitionDetail({
                     description: work.description ?? undefined,
                     likes: work.likes,
                     liked: work.liked,
+                    videoUrl: work.videoUrl,
                   }}
                   exhibitionId={exhibition.id}
                   exhibitionTitle={exhibition.title}
                   exhibitionHost={exhibition.host}
                   isLoggedIn={isLoggedIn}
+                  isOwner={isOwner}
                 />
               ))}
             </div>

--- a/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fal } from '@fal-ai/client';
+import { createClient } from '@/lib/supabase/server';
+import { checkExhibitionOwner, checkRole } from '@/lib/gallery/checkRole';
+
+export const maxDuration = 180;
+
+fal.config({ credentials: process.env.FALAI_API_KEY });
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ artworksId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+    const { artworksId: artworkId } = await params;
+
+    const roleCheck = await checkRole(supabase);
+    if (!roleCheck.ok) {
+      return NextResponse.json(
+        { message: roleCheck.message },
+        { status: roleCheck.status }
+      );
+    }
+
+    const ownerCheck = await checkExhibitionOwner(
+      supabase,
+      artworkId,
+      roleCheck.user.id,
+      'artwork'
+    );
+    if (!ownerCheck.ok) {
+      return NextResponse.json(
+        { message: ownerCheck.message },
+        { status: ownerCheck.status }
+      );
+    }
+
+    const { data: artwork, error: artworkError } = await supabase
+      .from('artworks')
+      .select('image_url, video_url')
+      .eq('id', artworkId)
+      .single();
+
+    if (artworkError || !artwork) {
+      return NextResponse.json({ message: 'artwork not found' }, { status: 404 });
+    }
+
+    if (artwork.video_url) {
+      return NextResponse.json({ videoUrl: artwork.video_url }, { status: 200 });
+    }
+
+    const result = await fal.subscribe('fal-ai/wan-25-preview/image-to-video', {
+      input: {
+        image_url: artwork.image_url,
+        prompt:
+          "A children's hand-drawn illustration comes to life with soft, looping animation. The main subject gently moves: characters walk in place or sway, animals breathe and blink, plants and trees rustle slowly, water ripples calmly. Background elements move subtly at a slower pace than foreground. Strictly preserve the original flat 2D illustration style, crayon and paint textures, and color palette. Characters maintain their original shape and proportions throughout. No photorealism. No camera movement. Smooth, cute, cheerful motion.",
+        negative_prompt:
+          "photorealistic, 3D render, morphing, warping, distortion, flickering, camera pan, camera zoom, blurry, deformed characters, style change",
+        resolution: '480p',
+      },
+    });
+
+    const videoUrl = (result.data as { video?: { url?: string } })?.video?.url;
+    if (!videoUrl) {
+      return NextResponse.json({ message: 'video generation failed' }, { status: 500 });
+    }
+
+    await supabase
+      .from('artworks')
+      .update({ video_url: videoUrl })
+      .eq('id', artworkId);
+
+    return NextResponse.json({ videoUrl }, { status: 200 });
+  } catch (err: unknown) {
+    console.error('animate error:', JSON.stringify(err, null, 2));
+    const detail = (err as { body?: { detail?: { type?: string }[] } })?.body?.detail?.[0];
+    if (detail?.type === 'image_dimension_error') {
+      return NextResponse.json(
+        { message: '이미지 해상도가 너무 낮아 애니메이션을 생성할 수 없습니다.' },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({ message: 'unknown error' }, { status: 500 });
+  }
+}

--- a/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
@@ -43,11 +43,17 @@ export async function POST(
       .single();
 
     if (artworkError || !artwork) {
-      return NextResponse.json({ message: 'artwork not found' }, { status: 404 });
+      return NextResponse.json(
+        { message: 'artwork not found' },
+        { status: 404 }
+      );
     }
 
     if (artwork.video_url) {
-      return NextResponse.json({ videoUrl: artwork.video_url }, { status: 200 });
+      return NextResponse.json(
+        { videoUrl: artwork.video_url },
+        { status: 200 }
+      );
     }
 
     const result = await fal.subscribe('fal-ai/wan-25-preview/image-to-video', {
@@ -56,14 +62,17 @@ export async function POST(
         prompt:
           "A children's hand-drawn illustration comes to life with soft, looping animation. The main subject gently moves: characters walk in place or sway, animals breathe and blink, plants and trees rustle slowly, water ripples calmly. Background elements move subtly at a slower pace than foreground. Strictly preserve the original flat 2D illustration style, crayon and paint textures, and color palette. Characters maintain their original shape and proportions throughout. No photorealism. No camera movement. Smooth, cute, cheerful motion.",
         negative_prompt:
-          "photorealistic, 3D render, morphing, warping, distortion, flickering, camera pan, camera zoom, blurry, deformed characters, style change",
+          'photorealistic, 3D render, morphing, warping, distortion, flickering, camera pan, camera zoom, blurry, deformed characters, style change',
         resolution: '480p',
       },
     });
 
     const videoUrl = (result.data as { video?: { url?: string } })?.video?.url;
     if (!videoUrl) {
-      return NextResponse.json({ message: 'video generation failed' }, { status: 500 });
+      return NextResponse.json(
+        { message: 'video generation failed' },
+        { status: 500 }
+      );
     }
 
     const { error: updateError } = await supabase
@@ -73,16 +82,22 @@ export async function POST(
 
     if (updateError) {
       console.error('video_url update error:', updateError);
-      return NextResponse.json({ message: 'database update error' }, { status: 500 });
+      return NextResponse.json(
+        { message: 'database update error' },
+        { status: 500 }
+      );
     }
 
     return NextResponse.json({ videoUrl }, { status: 200 });
   } catch (err: unknown) {
     console.error('animate error:', JSON.stringify(err, null, 2));
-    const detail = (err as { body?: { detail?: { type?: string }[] } })?.body?.detail?.[0];
+    const detail = (err as { body?: { detail?: { type?: string }[] } })?.body
+      ?.detail?.[0];
     if (detail?.type === 'image_dimension_error') {
       return NextResponse.json(
-        { message: '이미지 해상도가 너무 낮아 애니메이션을 생성할 수 없습니다.' },
+        {
+          message: '이미지 해상도가 너무 낮아 애니메이션을 생성할 수 없습니다.',
+        },
         { status: 400 }
       );
     }

--- a/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
@@ -66,10 +66,15 @@ export async function POST(
       return NextResponse.json({ message: 'video generation failed' }, { status: 500 });
     }
 
-    await supabase
+    const { error: updateError } = await supabase
       .from('artworks')
       .update({ video_url: videoUrl })
       .eq('id', artworkId);
+
+    if (updateError) {
+      console.error('video_url update error:', updateError);
+      return NextResponse.json({ message: 'database update error' }, { status: 500 });
+    }
 
     return NextResponse.json({ videoUrl }, { status: 200 });
   } catch (err: unknown) {

--- a/src/app/api/exhibitions/[exhibitionId]/artworks/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/artworks/route.ts
@@ -117,7 +117,7 @@ export async function GET(
 
     const { data: artworksRaw, error: artworksError } = await supabase
       .from('artworks')
-      .select('id,title,artist_name,description,image_url')
+      .select('id,title,artist_name,description,image_url,video_url')
       .eq('exhibition_id', exhibitionId);
 
     if (artworksError) {

--- a/src/components/exhibition-gallery/threejs/InnerWall.tsx
+++ b/src/components/exhibition-gallery/threejs/InnerWall.tsx
@@ -55,6 +55,7 @@ export default function InnerWalls({
                 htmlRef={(el) => {
                   htmlRefs.current[front] = el;
                 }}
+                videoUrl={init[front].video_url}
               />
             )}
 
@@ -71,6 +72,7 @@ export default function InnerWalls({
                   htmlRef={(el) => {
                     htmlRefs.current[back] = el;
                   }}
+                  videoUrl={init[back].video_url}
                 />
               </group>
             )}

--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Group, Texture, Vector3, VideoTexture } from 'three';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
@@ -30,32 +30,29 @@ export default function Painting({
   videoUrl?: string | null;
 }) {
   const localRef = useRef<Group>(null);
-  const videoRef = useRef<HTMLVideoElement | null>(null);
   const isNearRef = useRef(false);
   const [isNear, setIsNear] = useState(false);
-  const [videoTexture, setVideoTexture] = useState<VideoTexture | null>(null);
 
-  useEffect(() => {
-    if (!videoUrl) return;
+  const videoData = useMemo(() => {
+    if (!videoUrl) return null;
     const video = document.createElement('video');
     video.crossOrigin = 'anonymous';
     video.src = videoUrl;
     video.loop = true;
     video.muted = true;
     video.playsInline = true;
-    const texture = new VideoTexture(video);
-    videoRef.current = video;
-    setVideoTexture(texture);
-    return () => {
-      video.pause();
-      texture.dispose();
-      videoRef.current = null;
-      setVideoTexture(null);
-    };
+    return { video, texture: new VideoTexture(video) };
   }, [videoUrl]);
 
+  useEffect(() => {
+    return () => {
+      videoData?.video.pause();
+      videoData?.texture.dispose();
+    };
+  }, [videoData]);
+
   useFrame(({ camera }) => {
-    if (!localRef.current || !videoRef.current) return;
+    if (!localRef.current || !videoData) return;
     const worldPos = new Vector3();
     localRef.current.getWorldPosition(worldPos);
     const near = camera.position.distanceTo(worldPos) < VIDEO_NEAR_THRESHOLD;
@@ -63,14 +60,14 @@ export default function Painting({
       isNearRef.current = near;
       setIsNear(near);
       if (near) {
-        videoRef.current.play().catch(() => {});
+        videoData.video.play().catch(() => {});
       } else {
-        videoRef.current.pause();
+        videoData.video.pause();
       }
     }
   });
 
-  const displayTexture = isNear && videoTexture ? videoTexture : img;
+  const displayTexture = isNear && videoData ? videoData.texture : img;
   const [imgW, imgH] = checkImgSize(displayTexture, w, h, 0.4);
 
   if (!details) return null;

--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
-import { Group, Texture, VideoTexture } from 'three';
+import { useEffect, useRef, useState } from 'react';
+import { Group, Texture, Vector3, VideoTexture } from 'three';
+import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import { Download, Heart } from 'lucide-react';
 import { checkImgSize } from '@/lib/gallery/image';
@@ -9,6 +10,7 @@ const FRAME_M = 0.09;
 const MAT_M = 0.035;
 const FRAME_D = 0.06;
 const MAT_D = 0.035;
+const VIDEO_NEAR_THRESHOLD = 5;
 
 export default function Painting({
   img,
@@ -27,6 +29,10 @@ export default function Painting({
   htmlRef?: (el: HTMLDivElement | null) => void;
   videoUrl?: string | null;
 }) {
+  const localRef = useRef<Group>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const isNearRef = useRef(false);
+  const [isNear, setIsNear] = useState(false);
   const [videoTexture, setVideoTexture] = useState<VideoTexture | null>(null);
 
   useEffect(() => {
@@ -34,21 +40,37 @@ export default function Painting({
     const video = document.createElement('video');
     video.crossOrigin = 'anonymous';
     video.src = videoUrl;
-    video.autoplay = true;
     video.loop = true;
     video.muted = true;
     video.playsInline = true;
     const texture = new VideoTexture(video);
+    videoRef.current = video;
     setVideoTexture(texture);
-    video.play().catch(() => {});
     return () => {
       video.pause();
       texture.dispose();
+      videoRef.current = null;
       setVideoTexture(null);
     };
   }, [videoUrl]);
 
-  const displayTexture = videoTexture ?? img;
+  useFrame(({ camera }) => {
+    if (!localRef.current || !videoRef.current) return;
+    const worldPos = new Vector3();
+    localRef.current.getWorldPosition(worldPos);
+    const near = camera.position.distanceTo(worldPos) < VIDEO_NEAR_THRESHOLD;
+    if (near !== isNearRef.current) {
+      isNearRef.current = near;
+      setIsNear(near);
+      if (near) {
+        videoRef.current.play().catch(() => {});
+      } else {
+        videoRef.current.pause();
+      }
+    }
+  });
+
+  const displayTexture = isNear && videoTexture ? videoTexture : img;
   const [imgW, imgH] = checkImgSize(displayTexture, w, h, 0.4);
 
   if (!details) return null;
@@ -57,7 +79,13 @@ export default function Painting({
   const imgZ = matZ + MAT_D / 2 + 0.006;
 
   return (
-    <group ref={paintingRef} position={[0, 0, 0.3]}>
+    <group
+      ref={(el) => {
+        localRef.current = el;
+        paintingRef?.(el);
+      }}
+      position={[0, 0, 0.3]}
+    >
       {/* 외부 프레임 */}
       <mesh>
         <boxGeometry args={[imgW + FRAME_M * 2, imgH + FRAME_M * 2, FRAME_D]} />

--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -1,4 +1,5 @@
-import { Group, Texture } from 'three';
+import { useEffect, useState } from 'react';
+import { Group, Texture, VideoTexture } from 'three';
 import { Html } from '@react-three/drei';
 import { Download, Heart } from 'lucide-react';
 import { checkImgSize } from '@/lib/gallery/image';
@@ -16,6 +17,7 @@ export default function Painting({
   h,
   paintingRef,
   htmlRef,
+  videoUrl,
 }: {
   img: Texture;
   details: GalleryUIArtworkProps;
@@ -23,8 +25,31 @@ export default function Painting({
   h: number;
   paintingRef?: (mesh: Group | null) => void;
   htmlRef?: (el: HTMLDivElement | null) => void;
+  videoUrl?: string | null;
 }) {
-  const [imgW, imgH] = checkImgSize(img, w, h, 0.4);
+  const [videoTexture, setVideoTexture] = useState<VideoTexture | null>(null);
+
+  useEffect(() => {
+    if (!videoUrl) return;
+    const video = document.createElement('video');
+    video.crossOrigin = 'anonymous';
+    video.src = videoUrl;
+    video.autoplay = true;
+    video.loop = true;
+    video.muted = true;
+    video.playsInline = true;
+    video.play();
+    const texture = new VideoTexture(video);
+    setVideoTexture(texture);
+    return () => {
+      video.pause();
+      texture.dispose();
+      setVideoTexture(null);
+    };
+  }, [videoUrl]);
+
+  const displayTexture = videoTexture ?? img;
+  const [imgW, imgH] = checkImgSize(displayTexture, w, h, 0.4);
 
   if (!details) return null;
 
@@ -52,7 +77,7 @@ export default function Painting({
       {/* 작품 이미지 */}
       <mesh position={[0, 0, imgZ]}>
         <planeGeometry args={[imgW, imgH]} />
-        <meshStandardMaterial map={img} />
+        <meshStandardMaterial map={displayTexture} />
       </mesh>
 
       {/* 작품 정보 */}

--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -38,9 +38,9 @@ export default function Painting({
     video.loop = true;
     video.muted = true;
     video.playsInline = true;
-    video.play();
     const texture = new VideoTexture(video);
     setVideoTexture(texture);
+    video.play().catch(() => {});
     return () => {
       video.pause();
       texture.dispose();

--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -55,7 +55,8 @@ export default function Painting({
   useFrame(({ camera }) => {
     if (!localRef.current || !videoData) return;
     localRef.current.getWorldPosition(worldPosRef.current);
-    const near = camera.position.distanceTo(worldPosRef.current) < VIDEO_NEAR_THRESHOLD;
+    const near =
+      camera.position.distanceTo(worldPosRef.current) < VIDEO_NEAR_THRESHOLD;
     if (near !== isNearRef.current) {
       isNearRef.current = near;
       setIsNear(near);

--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -30,6 +30,7 @@ export default function Painting({
   videoUrl?: string | null;
 }) {
   const localRef = useRef<Group>(null);
+  const worldPosRef = useRef(new Vector3());
   const isNearRef = useRef(false);
   const [isNear, setIsNear] = useState(false);
 
@@ -53,9 +54,8 @@ export default function Painting({
 
   useFrame(({ camera }) => {
     if (!localRef.current || !videoData) return;
-    const worldPos = new Vector3();
-    localRef.current.getWorldPosition(worldPos);
-    const near = camera.position.distanceTo(worldPos) < VIDEO_NEAR_THRESHOLD;
+    localRef.current.getWorldPosition(worldPosRef.current);
+    const near = camera.position.distanceTo(worldPosRef.current) < VIDEO_NEAR_THRESHOLD;
     if (near !== isNearRef.current) {
       isNearRef.current = near;
       setIsNear(near);

--- a/src/components/exhibition-gallery/threejs/Scene.tsx
+++ b/src/components/exhibition-gallery/threejs/Scene.tsx
@@ -77,7 +77,17 @@ export default function Scene2({
     circleCollidersRef.current = c;
   }, []);
 
-  const { atmosphere, lighting } = preset;
+  const atmosphere = preset.atmosphere ?? defaultPreset.atmosphere;
+  const lighting = preset.lighting ?? defaultPreset.lighting;
+  const mergedPreset: typeof preset = {
+    ...defaultPreset,
+    ...preset,
+    atmosphere,
+    lighting,
+    decorations: preset.decorations ?? defaultPreset.decorations,
+    particles: preset.particles ?? defaultPreset.particles,
+    floor: preset.floor ?? defaultPreset.floor,
+  };
 
   return (
     <Canvas
@@ -191,12 +201,12 @@ export default function Scene2({
         walls={walls}
         innerWalls={innerWalls}
         init={init}
-        floorConfig={preset.floor}
-        wallColor={preset.wallColor}
-        wallPattern={preset.wallPattern}
+        floorConfig={mergedPreset.floor}
+        wallColor={mergedPreset.wallColor}
+        wallPattern={mergedPreset.wallPattern}
       />
       <DynamicDecorations
-        preset={preset}
+        preset={mergedPreset}
         size={roomSize}
         height={height}
         cellSize={cellSize}

--- a/src/components/exhibition/WorkDialog.tsx
+++ b/src/components/exhibition/WorkDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { Download, Heart, X } from 'lucide-react';
+import { Download, Heart, Sparkles, X } from 'lucide-react';
 import {
   Dialog,
   DialogClose,
@@ -14,6 +14,7 @@ import { toggleArtworkLike } from '@/lib/artwork/service';
 import { cn } from '@/lib/utils';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import { useImageDownload } from '@/hooks/useImageDownload';
+import { useState } from 'react';
 
 export interface Work {
   id: string;
@@ -23,6 +24,7 @@ export interface Work {
   description?: string;
   likes: number;
   liked: boolean;
+  videoUrl?: string | null;
 }
 
 interface WorkDialogProps {
@@ -31,6 +33,7 @@ interface WorkDialogProps {
   exhibitionTitle: string;
   exhibitionHost: string;
   isLoggedIn?: boolean;
+  isOwner?: boolean;
 }
 
 export default function WorkDialog({
@@ -39,6 +42,7 @@ export default function WorkDialog({
   exhibitionTitle,
   exhibitionHost,
   isLoggedIn = false,
+  isOwner = false,
 }: WorkDialogProps) {
   const { download } = useImageDownload();
 
@@ -62,6 +66,31 @@ export default function WorkDialog({
       toggleArtworkLike(exhibitionId, work.id, nextLiked),
     refreshOnSuccess: true,
   });
+
+  const [videoUrl, setVideoUrl] = useState<string | null>(work.videoUrl ?? null);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const handleAnimate = async () => {
+    if (isAnimating) return;
+    setIsAnimating(true);
+    try {
+      const res = await fetch(
+        `/api/exhibitions/${exhibitionId}/artworks/${work.id}/animate`,
+        { method: 'POST' }
+      );
+      if (!res.ok) {
+        const { message } = await res.json().catch(() => ({}));
+        throw new Error(message || 'animate failed');
+      }
+      const { videoUrl: url } = await res.json();
+      setVideoUrl(url);
+    } catch (err) {
+      console.error(err);
+      alert(err instanceof Error ? err.message : '애니메이션 생성에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsAnimating(false);
+    }
+  };
 
   return (
     <Dialog>
@@ -93,15 +122,26 @@ export default function WorkDialog({
         >
           <X className="text-secondary h-4 w-4" />
         </DialogClose>
-        {/* 작품 이미지 */}
+        {/* 작품 이미지 / 영상 */}
         <div className="relative aspect-4/3 w-full bg-[#F5EFE0]">
-          <Image
-            src={work.image}
-            alt={work.title}
-            fill
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
-            className="object-cover"
-          />
+          {videoUrl ? (
+            <video
+              src={videoUrl}
+              autoPlay
+              loop
+              muted
+              playsInline
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <Image
+              src={work.image}
+              alt={work.title}
+              fill
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+              className="object-cover"
+            />
+          )}
         </div>
         {/* 정보 영역 */}
         <div className="space-y-4 p-6">
@@ -137,6 +177,23 @@ export default function WorkDialog({
               >
                 <Download className="h-4 w-4" />
               </button>
+              {isOwner && !videoUrl && (
+                <button
+                  type="button"
+                  onClick={handleAnimate}
+                  disabled={isAnimating}
+                  aria-label="움직이게 하기"
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded-full px-2 py-1 text-sm font-medium transition-colors',
+                    isAnimating
+                      ? 'cursor-not-allowed bg-purple-50 text-purple-300'
+                      : 'bg-purple-50 text-purple-600 hover:bg-purple-100'
+                  )}
+                >
+                  <Sparkles className="h-3.5 w-3.5" />
+                  {isAnimating ? '생성 중...' : '움직이게 하기'}
+                </button>
+              )}
             </div>
           </div>
 

--- a/src/components/exhibition/WorkDialog.tsx
+++ b/src/components/exhibition/WorkDialog.tsx
@@ -60,7 +60,9 @@ export default function WorkDialog({
     }
   };
 
-  const [videoUrl, setVideoUrl] = useState<string | null>(work.videoUrl ?? null);
+  const [videoUrl, setVideoUrl] = useState<string | null>(
+    work.videoUrl ?? null
+  );
   const [isAnimating, setIsAnimating] = useState(false);
 
   const handleAnimate = async () => {
@@ -79,7 +81,11 @@ export default function WorkDialog({
       setVideoUrl(url);
     } catch (err) {
       console.error(err);
-      alert(err instanceof Error ? err.message : '애니메이션 생성에 실패했습니다. 다시 시도해주세요.');
+      alert(
+        err instanceof Error
+          ? err.message
+          : '애니메이션 생성에 실패했습니다. 다시 시도해주세요.'
+      );
     } finally {
       setIsAnimating(false);
     }

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -43,6 +43,7 @@ export default function ArtworkDetailContent({
   onAnimate,
 }: ArtworkDetailContentProps) {
   const [showLoginHint, setShowLoginHint] = useState(false);
+  const [showVideo, setShowVideo] = useState(false);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -90,7 +91,7 @@ export default function ArtworkDetailContent({
 
         {/* 이미지 / 영상 */}
         <div className="relative aspect-4/3 w-full bg-[#E8E5DE]">
-          {videoUrl ? (
+          {showVideo && videoUrl ? (
             <video
               src={videoUrl}
               autoPlay
@@ -107,6 +108,14 @@ export default function ArtworkDetailContent({
               className="object-cover"
               sizes="530px"
             />
+          )}
+          {videoUrl && (
+            <button
+              onClick={() => setShowVideo((v) => !v)}
+              className="absolute bottom-3 right-3 flex items-center gap-1.5 rounded-full bg-black/50 px-3 py-1.5 text-[12px] font-medium text-white backdrop-blur-sm transition-colors hover:bg-black/70"
+            >
+              {showVideo ? '🖼 이미지 보기' : '▶ 영상 보기'}
+            </button>
           )}
         </div>
 

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -112,7 +112,7 @@ export default function ArtworkDetailContent({
           {videoUrl && (
             <button
               onClick={() => setShowVideo((v) => !v)}
-              className="absolute bottom-3 right-3 flex items-center gap-1.5 rounded-full bg-black/50 px-3 py-1.5 text-[12px] font-medium text-white backdrop-blur-sm transition-colors hover:bg-black/70"
+              className="absolute right-3 bottom-3 flex items-center gap-1.5 rounded-full bg-black/50 px-3 py-1.5 text-[12px] font-medium text-white backdrop-blur-sm transition-colors hover:bg-black/70"
             >
               {showVideo ? '🖼 이미지 보기' : '▶ 영상 보기'}
             </button>

--- a/src/lib/exhibition/server.ts
+++ b/src/lib/exhibition/server.ts
@@ -189,6 +189,7 @@ export type ExhibitionWorkItem = {
   description: string | null;
   likes: number;
   liked: boolean;
+  videoUrl: string | null;
 };
 
 export type ExhibitionDetailItem = {
@@ -230,7 +231,7 @@ export async function fetchExhibitionDetail(
       teacher_id,
       likes_count,
       profile:profiles!teacher_id ( institution ),
-      artworks ( id, title, artist_name, description, image_url )
+      artworks ( id, title, artist_name, description, image_url, video_url )
     `
     )
     .eq('id', exhibitionId)
@@ -302,6 +303,7 @@ export async function fetchExhibitionDetail(
       description: work.description,
       likes: likesCountMap.get(work.id) ?? 0,
       liked: likedArtworkIds.has(work.id),
+      videoUrl: work.video_url ?? null,
     })),
   };
 }

--- a/src/types/exhibition.ts
+++ b/src/types/exhibition.ts
@@ -51,6 +51,7 @@ export type ArtworkRow = {
   artist_name: string;
   image_url: string;
   description: string | null;
+  video_url: string | null;
 };
 
 export type ReviewRow = {

--- a/src/types/gallery.ts
+++ b/src/types/gallery.ts
@@ -45,6 +45,7 @@ export type GalleryUIArtworkProps = {
   artist_name: string;
   description: null | string;
   image_url: string;
+  video_url?: string | null;
   likes: number;
   likesByMe: boolean;
 };

--- a/supabase/migration/0006_artworks_video_url.sql
+++ b/supabase/migration/0006_artworks_video_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE artworks ADD COLUMN IF NOT EXISTS video_url TEXT;


### PR DESCRIPTION
## 📌 개요

아이들의 그림 작품(이미지 파일)을 동적으로 움직일 수 있게 AI를 활용하여 영상으로 변환하는 기능을 구현했습니다. 
FAL.ai의 WAN-Video v2.5 Image-to-Video 모델을 활용하였고, 선생님(only 전시관 생성자)만 버튼을 통해 생성할 수 있습니다. 
생성된 영상은 DB에 저장되어 이후 작품 상세 모달과 3D 전시관 양쪽에서 모두 감상할 수 있도록 구현했습니다.

## 🔍 변경 사항

### AI 그림 애니메이션
- 작품 상세 모달에 움직이게 하기 버튼 추가 (선생님/오너 계정에만 노출)
- 버튼 클릭 시 FAL.ai wan-25-preview/image-to-video 모델 호출 -> 5초 480p 영상 생성
- 생성된 영상 URL을 artworks.video_url 컬럼(DB)에 저장 -> 이후 재호출 시 재사용 (idempotent)
- 이미지 해상도가 240px 미만인 경우 한국어 에러 메시지 반환

### 작품 상세 모달 (ArtworkDetailContent)

- 기본은 정적 이미지로 표시
- video_url 있는 작품은 우하단에 (▶ 영상 보기 버튼) 노출 -> 클릭 시 영상/이미지 토글

### 3D 갤러리 VideoTexture 적용
- artworks GET API에 video_url 필드 추가
- GalleryUIArtworkProps 타입에 video_url 추가
- Painting.tsx에 거리 기반 전환 구현: 사용자가 5유닛 이내 접근 시 영상 자동 재생, 멀어지면 정지 + 정적 이미지로 전환
- InnerWall.tsx에서 init[i].video_url -> Painting에 전달

### DB 마이그레이션
- supabase/migration/0006_artworks_video_url.sql: artworks 테이블에 video_url TEXT 컬럼 추가

## 🔗 관련 이슈 번호

close #153 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1178" height="726" alt="스크린샷 2026-06-08 오후 12 15 13" src="https://github.com/user-attachments/assets/03e9fa85-126a-4d7a-bfd9-0b024de09951" />


<img width="1178" height="726" alt="스크린샷 2026-06-08 오후 12 12 04" src="https://github.com/user-attachments/assets/92b2107e-74aa-4c58-bf12-58a0cc3a8706" />

<img width="1178" height="726" alt="스크린샷 2026-06-08 오후 12 12 13" src="https://github.com/user-attachments/assets/211f2064-a6bb-4fdd-a3e0-558d31380bcb" />

<img width="1178" height="726" alt="스크린샷 2026-06-08 오후 12 05 32" src="https://github.com/user-attachments/assets/a580c269-cb13-4adc-a342-631ad392e738" />

<img width="1178" height="726" alt="스크린샷 2026-06-08 오후 12 13 05" src="https://github.com/user-attachments/assets/d68ad62a-0aee-459e-8e97-59e3d87807f9" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- 영상 생성 비용: $0.25/영상 (FAL.ai WAN 2.5, 5초 480p 기준)

- 환경변수 설정 필요
로컬 .env.local: `FALAI_API_KEY=발급받은_키`

- FAL.ai 키 발급: https://fal.ai/dashboard/keys

- Vercel 배포 시 프로젝트 설정 → Environment Variables에 동일하게 추가

> 키 미설정 시 /animate API 호출 시 403 Forbidden 발생.

- Supabase artworks 테이블에 video_url TEXT 컬럼 마이그레이션 선행 필요
supabase/migration/0006_artworks_video_url.sql 파일 내용을 Supabase 대시보드 SQL Editor에서 실행

> 미적용 시 영상 URL DB 저장 실패.