### PR TITLE
[PR] 멀티/ 채팅 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,12 +39,15 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/three": "^0.184.0",
+        "@types/ws": "^8.18.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.7.3",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "tsx": "^4.22.4",
+        "typescript": "^5",
+        "ws": "^8.21.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -790,6 +793,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4829,6 +5274,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5711,6 +6198,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -10057,6 +10559,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/tunnel-rat": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
@@ -10660,9 +11181,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "ws": "tsx server/ws.ts",
+    "ws:watch": "tsx watch server/ws.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.100.1",
@@ -40,11 +42,14 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/three": "^0.184.0",
+    "@types/ws": "^8.18.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "tsx": "^4.22.4",
+    "typescript": "^5",
+    "ws": "^8.21.0"
   }
 }

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -10,11 +10,11 @@ type PlayerState = {
   z: number;
   yaw: number;
 };
-type Chat={
-  userId:string;
-  message:string;
-  timestamp:string;
-}
+type Chat = {
+  userId: string;
+  message: string;
+  timestamp: string;
+};
 type RoomEntry = {
   ws: WebSocket;
   state: PlayerState | null;
@@ -25,7 +25,7 @@ type RoomEntry = {
 // roomId → (userId → RoomEntry)
 const rooms = new Map<string, Map<string, RoomEntry>>();
 //roomId,Chat
-const roomChats=new Map<string, Chat[]>();
+const roomChats = new Map<string, Chat[]>();
 const wss = new WebSocketServer({ port: PORT });
 
 function getRoomId(req: IncomingMessage): string | null {
@@ -33,7 +33,11 @@ function getRoomId(req: IncomingMessage): string | null {
   return match ? match[1] : null;
 }
 
-function broadcast(room: Map<string, RoomEntry>, senderId: string, raw: string) {
+function broadcast(
+  room: Map<string, RoomEntry>,
+  senderId: string,
+  raw: string
+) {
   room.forEach((entry, id) => {
     if (id !== senderId && entry.ws.readyState === WebSocket.OPEN) {
       entry.ws.send(raw);
@@ -49,9 +53,9 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
   }
 
   if (!rooms.has(roomId)) rooms.set(roomId, new Map());
-  if(!roomChats.has(roomId)) roomChats.set(roomId,[])
+  if (!roomChats.has(roomId)) roomChats.set(roomId, []);
   const room = rooms.get(roomId)!;
-  const roomChat=roomChats.get(roomId)!;
+  const roomChat = roomChats.get(roomId)!;
   let myUserId: string | null = null;
 
   ws.on('message', (data) => {
@@ -73,12 +77,20 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
       const userName = (msg.userName as string) || userId;
       room.set(userId, { ws, state: null, chat: [], userName });
 
-      console.log(`[ws] join  room=${roomId} userId=${userId} total=${room.size}`);
+      console.log(
+        `[ws] join  room=${roomId} userId=${userId} total=${room.size}`
+      );
 
       // 기존 플레이어 상태를 신규 접속자에게 전송
       room.forEach((entry, id) => {
         if (id !== userId && ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'join', userId: id, userName: entry.userName }));
+          ws.send(
+            JSON.stringify({
+              type: 'join',
+              userId: id,
+              userName: entry.userName,
+            })
+          );
           if (entry.state) {
             ws.send(JSON.stringify({ type: 'move', ...entry.state }));
           }
@@ -90,20 +102,19 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
       return;
     }
 
-    if(type==='message'){
-      const chat:Chat ={
+    if (type === 'message') {
+      const chat: Chat = {
         userId,
-        timestamp:Date.now().toString(),
-        message:msg.message as string
-      }
+        timestamp: Date.now().toString(),
+        message: msg.message as string,
+      };
       if (room.has(userId)) {
-        roomChat.push(chat)
-        const prevChat=[...room.get(userId)!.chat]
-        room.get(userId)!.chat = [...prevChat,chat];
-        console.log(roomChat)
+        roomChat.push(chat);
+        const prevChat = [...room.get(userId)!.chat];
+        room.get(userId)!.chat = [...prevChat, chat];
+        console.log(roomChat);
       }
       broadcast(room, userId, raw);
-
     }
     if (type === 'move') {
       const state: PlayerState = {
@@ -125,7 +136,9 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
     if (type === 'leave') {
       broadcast(room, userId, raw);
       room.delete(userId);
-      console.log(`[ws] leave room=${roomId} userId=${userId} remaining=${room.size}`);
+      console.log(
+        `[ws] leave room=${roomId} userId=${userId} remaining=${room.size}`
+      );
       if (room.size === 0) rooms.delete(roomId);
       return;
     }
@@ -134,10 +147,16 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
   ws.on('close', () => {
     if (!myUserId) return;
     room.delete(myUserId);
-    console.log(`[ws] closed room=${roomId} userId=${myUserId} remaining=${room.size}`);
+    console.log(
+      `[ws] closed room=${roomId} userId=${myUserId} remaining=${room.size}`
+    );
 
     // 비정상 종료 시 다른 플레이어에게 퇴장 알림
-    broadcast(room, myUserId, JSON.stringify({ type: 'leave', userId: myUserId }));
+    broadcast(
+      room,
+      myUserId,
+      JSON.stringify({ type: 'leave', userId: myUserId })
+    );
     if (room.size === 0) rooms.delete(roomId);
   });
 

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -1,0 +1,149 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import { IncomingMessage } from 'http';
+
+const PORT = parseInt(process.env.WS_PORT ?? '3001', 10);
+
+type PlayerState = {
+  userId: string;
+  x: number;
+  y: number;
+  z: number;
+  yaw: number;
+};
+type Chat={
+  userId:string;
+  message:string;
+  timestamp:string;
+}
+type RoomEntry = {
+  ws: WebSocket;
+  state: PlayerState | null;
+  chat: Chat[] | [];
+  userName: string;
+};
+
+// roomId → (userId → RoomEntry)
+const rooms = new Map<string, Map<string, RoomEntry>>();
+//roomId,Chat
+const roomChats=new Map<string, Chat[]>();
+const wss = new WebSocketServer({ port: PORT });
+
+function getRoomId(req: IncomingMessage): string | null {
+  const match = (req.url ?? '').match(/^\/gallery\/(.+)$/);
+  return match ? match[1] : null;
+}
+
+function broadcast(room: Map<string, RoomEntry>, senderId: string, raw: string) {
+  room.forEach((entry, id) => {
+    if (id !== senderId && entry.ws.readyState === WebSocket.OPEN) {
+      entry.ws.send(raw);
+    }
+  });
+}
+
+wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+  const roomId = getRoomId(req);
+  if (!roomId) {
+    ws.close(1008, 'invalid room');
+    return;
+  }
+
+  if (!rooms.has(roomId)) rooms.set(roomId, new Map());
+  if(!roomChats.has(roomId)) roomChats.set(roomId,[])
+  const room = rooms.get(roomId)!;
+  const roomChat=roomChats.get(roomId)!;
+  let myUserId: string | null = null;
+
+  ws.on('message', (data) => {
+    const raw = data.toString();
+    let msg: Record<string, unknown>;
+
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    const type = msg.type as string;
+    const userId = msg.userId as string;
+    if (!userId) return;
+
+    if (type === 'join') {
+      myUserId = userId;
+      const userName = (msg.userName as string) || userId;
+      room.set(userId, { ws, state: null, chat: [], userName });
+
+      console.log(`[ws] join  room=${roomId} userId=${userId} total=${room.size}`);
+
+      // 기존 플레이어 상태를 신규 접속자에게 전송
+      room.forEach((entry, id) => {
+        if (id !== userId && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'join', userId: id, userName: entry.userName }));
+          if (entry.state) {
+            ws.send(JSON.stringify({ type: 'move', ...entry.state }));
+          }
+        }
+      });
+
+      // 다른 플레이어에게 입장 알림
+      broadcast(room, userId, raw);
+      return;
+    }
+
+    if(type==='message'){
+      const chat:Chat ={
+        userId,
+        timestamp:Date.now().toString(),
+        message:msg.message as string
+      }
+      if (room.has(userId)) {
+        roomChat.push(chat)
+        const prevChat=[...room.get(userId)!.chat]
+        room.get(userId)!.chat = [...prevChat,chat];
+        console.log(roomChat)
+      }
+      broadcast(room, userId, raw);
+
+    }
+    if (type === 'move') {
+      const state: PlayerState = {
+        userId,
+        x: msg.x as number,
+        y: msg.y as number,
+        z: msg.z as number,
+        yaw: msg.yaw as number,
+      };
+
+      if (room.has(userId)) {
+        room.get(userId)!.state = state;
+      }
+
+      broadcast(room, userId, raw);
+      return;
+    }
+
+    if (type === 'leave') {
+      broadcast(room, userId, raw);
+      room.delete(userId);
+      console.log(`[ws] leave room=${roomId} userId=${userId} remaining=${room.size}`);
+      if (room.size === 0) rooms.delete(roomId);
+      return;
+    }
+  });
+
+  ws.on('close', () => {
+    if (!myUserId) return;
+    room.delete(myUserId);
+    console.log(`[ws] closed room=${roomId} userId=${myUserId} remaining=${room.size}`);
+
+    // 비정상 종료 시 다른 플레이어에게 퇴장 알림
+    broadcast(room, myUserId, JSON.stringify({ type: 'leave', userId: myUserId }));
+    if (room.size === 0) rooms.delete(roomId);
+  });
+
+  ws.on('error', (err) => {
+    console.error(`[ws] error room=${roomId}:`, err.message);
+  });
+});
+
+console.log(`[ws] server listening on ws://localhost:${PORT}`);

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -1,7 +1,7 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import { IncomingMessage } from 'http';
 
-const PORT = parseInt(process.env.WS_PORT ?? '3001', 10);
+const PORT = parseInt(process.env.PORT ?? '3001', 10);
 
 type PlayerState = {
   userId: string;

--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import {  useState } from 'react';
+import { useState } from 'react';
 import { useGalleryData } from '@/lib/gallery/hooks';
 import { usePlayerSocket } from '@/hooks/usePlayerSocket';
 import GalleryEntryModal from '@/components/exhibition-gallery/GalleryEntryModal';
@@ -21,18 +21,17 @@ export default function GalleryExhibitionPage() {
     initError,
   } = useGalleryData(id);
 
-  const { sendMove, sendMessage, remotePlayersRef, playerInfo, chatHistory } = usePlayerSocket(
-    id,
-    user?.id ?? null,
-    user?.user_metadata?.username ?? 'guest'
-  );
+  const { sendMove, sendMessage, remotePlayersRef, playerInfo, chatHistory } =
+    usePlayerSocket(
+      id,
+      user?.id ?? null,
+      user?.user_metadata?.username ?? 'guest'
+    );
 
   const [isSceneReady, setIsSceneReady] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
   const [started, setStarted] = useState(false);
   const isAllReady = isInitReady && isSceneReady;
-
-
 
   if (initError) {
     return (

--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import {  useState } from 'react';
 import { useGalleryData } from '@/lib/gallery/hooks';
+import { usePlayerSocket } from '@/hooks/usePlayerSocket';
 import GalleryEntryModal from '@/components/exhibition-gallery/GalleryEntryModal';
 import GalleryHUD from '@/components/exhibition-gallery/GalleryHUD';
 import Scene2 from '@/components/exhibition-gallery/threejs/Scene';
@@ -20,11 +21,18 @@ export default function GalleryExhibitionPage() {
     initError,
   } = useGalleryData(id);
 
+  const { sendMove, sendMessage, remotePlayersRef, playerInfo, chatHistory } = usePlayerSocket(
+    id,
+    user?.id ?? null,
+    user?.user_metadata?.username ?? 'guest'
+  );
+
   const [isSceneReady, setIsSceneReady] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
   const [started, setStarted] = useState(false);
-
   const isAllReady = isInitReady && isSceneReady;
+
+
 
   if (initError) {
     return (
@@ -59,6 +67,11 @@ export default function GalleryExhibitionPage() {
         isMuted={isMuted}
         onMute={() => setIsMuted(true)}
         onBack={() => router.back()}
+        isLogged={!!user}
+        myName={user?.user_metadata?.username ?? 'guest'}
+        playerNames={playerInfo.map((p) => p.userName)}
+        sendMessage={sendMessage}
+        chatHistory={chatHistory}
       />
 
       <div
@@ -71,10 +84,13 @@ export default function GalleryExhibitionPage() {
         {isInitReady && (
           <Scene2
             preset={galleryPreset ?? undefined}
-            user={user}
+            canLikes={!!user}
             exhibitionId={id}
             ready={setIsSceneReady}
             init={artworks}
+            sendMove={sendMove}
+            remotePlayersRef={remotePlayersRef}
+            playerInfo={playerInfo}
           />
         )}
       </div>

--- a/src/components/exhibition-gallery/GalleryHUD.tsx
+++ b/src/components/exhibition-gallery/GalleryHUD.tsx
@@ -49,7 +49,7 @@ export default function GalleryHUD({
         {isLogged && (
           <div className="pointer-events-auto flex cursor-pointer items-center gap-2 rounded-2xl bg-black/50 p-3 backdrop-blur-lg">
             <div className="flex flex-col items-center">
-              {[myName, playerNames].map((playerId, i) => (
+              {[myName, ...playerNames].map((playerId, i) => (
                 <p
                   key={i}
                   className={`font-bold ${playerId === myName ? 'text-yellow-400/80' : 'text-white/80'} `}

--- a/src/components/exhibition-gallery/GalleryHUD.tsx
+++ b/src/components/exhibition-gallery/GalleryHUD.tsx
@@ -2,6 +2,8 @@
 
 import { IoIosArrowBack } from 'react-icons/io';
 import { X } from 'lucide-react';
+import { useState } from 'react';
+import { ChatHistory } from '@/hooks/usePlayerSocket';
 
 interface GalleryHUDProps {
   title: string;
@@ -9,6 +11,11 @@ interface GalleryHUDProps {
   isMuted: boolean;
   onMute: () => void;
   onBack: () => void;
+  myName: string;
+  playerNames: string[];
+  sendMessage: (message: string) => void;
+  chatHistory: ChatHistory[];
+  isLogged:boolean;
 }
 
 export default function GalleryHUD({
@@ -17,25 +24,54 @@ export default function GalleryHUD({
   isMuted,
   onMute,
   onBack,
+  myName,
+  playerNames,
+  sendMessage,
+  chatHistory,
+  isLogged
 }: GalleryHUDProps) {
   return (
     <div className="pointer-events-none absolute inset-0 z-40 flex w-full items-start p-5">
-      <button
-        onClick={(e) => {
-          e.preventDefault();
-          onBack();
-        }}
-        className="pointer-events-auto flex cursor-pointer items-center gap-2 rounded-2xl bg-black/50 p-3 backdrop-blur-lg"
-      >
-        <IoIosArrowBack className="text-lg text-white/80" />
-        <div className="flex flex-col">
-          <p className="font-bold text-white/80">{title}</p>
-          <p className="text-sm text-white/30">{host}</p>
-        </div>
-      </button>
+      <div className={'flex w-full justify-between'}>
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            onBack();
+          }}
+          className="pointer-events-auto flex cursor-pointer items-center gap-2 rounded-2xl bg-black/50 p-3 backdrop-blur-lg"
+        >
+          <IoIosArrowBack className="text-lg text-white/80" />
+          <div className="flex flex-col">
+            <p className="font-bold text-white/80">{title}</p>
+            <p className="text-sm text-white/30">{host}</p>
+          </div>
+        </button>
+        {isLogged && (
+          <div className="pointer-events-auto flex cursor-pointer items-center gap-2 rounded-2xl bg-black/50 p-3 backdrop-blur-lg">
+            <div className="flex flex-col items-center">
+              {[myName, playerNames].map((playerId, i) => (
+                <p
+                  key={i}
+                  className={`font-bold ${playerId === myName ? 'text-yellow-400/80' : 'text-white/80'} `}
+                >
+                  {playerId}
+                </p>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {isLogged && (
+        <Chat
+          sendMessage={sendMessage}
+          chatHistory={chatHistory}
+          me={myName}
+        />
+      )}
 
       {!isMuted && (
-        <div className="pointer-events-none absolute bottom-0 left-1/2 flex -translate-x-1/2 items-center gap-2 p-5">
+        <div className="absolute bottom-0 left-1/2 flex -translate-x-1/2 items-center gap-2 p-5">
           <div className="flex items-center gap-3 rounded-lg bg-black/50 px-3 py-2 text-[14px] backdrop-blur-lg">
             <p className="text-white/80">숫자키 1 - 좋아요</p>
             <p className="text-white/80">숫자키 2 - 다운로드</p>
@@ -48,6 +84,71 @@ export default function GalleryHUD({
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+function Chat({ sendMessage, chatHistory,me='guest' }: {
+  sendMessage: (msg: string) => void;
+  chatHistory: ChatHistory[];
+  me:string;
+}) {
+  const [msg, setMsg] = useState('');
+  const messageHandler = (msg: string) => {
+    console.log(msg)
+    sendMessage(msg);
+  };
+  return (
+    <div
+      className="pointer-events-auto absolute bottom-0 left-0 m-5 flex w-72 flex-col gap-2 rounded-2xl bg-black/50 p-3 backdrop-blur-sm"
+      onClick={(e) => {
+        e.stopPropagation();
+        e.nativeEvent.stopImmediatePropagation();
+      }}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        e.nativeEvent.stopImmediatePropagation();
+      }}
+    >
+      {/* 메시지 목록 */}
+      <div className="flex max-h-40 flex-col-reverse gap-1 overflow-y-auto">
+        {[...chatHistory].reverse().map((x, i) => (
+          <div key={i} className="flex gap-2 text-sm">
+            <span
+              className={`shrink-0 ${me === x.userName ? 'text-yellow-400/80' : 'text-white/80'} font-semibold `}
+            >
+              {x.userName}
+            </span>
+            <span className="text-white/90">{x.message}</span>
+          </div>
+        ))}
+      </div>
+      {/* 입력창 */}
+      <div className="flex gap-2">
+        <input
+          value={msg}
+          onChange={(e) => setMsg(e.target.value)}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+              messageHandler(msg);
+              setMsg('');
+            }
+          }}
+          placeholder="메시지 입력..."
+          className="flex-1 rounded-lg bg-white/10 px-3 py-1.5 text-sm text-white placeholder-white/30 outline-none"
+        />
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            messageHandler(msg);
+            setMsg('');
+          }}
+          className="rounded-lg bg-white/20 px-3 py-1.5 text-sm text-white/80 hover:bg-white/30"
+        >
+          전송
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/exhibition-gallery/GalleryHUD.tsx
+++ b/src/components/exhibition-gallery/GalleryHUD.tsx
@@ -15,7 +15,7 @@ interface GalleryHUDProps {
   playerNames: string[];
   sendMessage: (message: string) => void;
   chatHistory: ChatHistory[];
-  isLogged:boolean;
+  isLogged: boolean;
 }
 
 export default function GalleryHUD({
@@ -28,7 +28,7 @@ export default function GalleryHUD({
   playerNames,
   sendMessage,
   chatHistory,
-  isLogged
+  isLogged,
 }: GalleryHUDProps) {
   return (
     <div className="pointer-events-none absolute inset-0 z-40 flex w-full items-start p-5">
@@ -63,11 +63,7 @@ export default function GalleryHUD({
       </div>
 
       {isLogged && (
-        <Chat
-          sendMessage={sendMessage}
-          chatHistory={chatHistory}
-          me={myName}
-        />
+        <Chat sendMessage={sendMessage} chatHistory={chatHistory} me={myName} />
       )}
 
       {!isMuted && (
@@ -88,14 +84,18 @@ export default function GalleryHUD({
   );
 }
 
-function Chat({ sendMessage, chatHistory,me='guest' }: {
+function Chat({
+  sendMessage,
+  chatHistory,
+  me = 'guest',
+}: {
   sendMessage: (msg: string) => void;
   chatHistory: ChatHistory[];
-  me:string;
+  me: string;
 }) {
   const [msg, setMsg] = useState('');
   const messageHandler = (msg: string) => {
-    console.log(msg)
+    console.log(msg);
     sendMessage(msg);
   };
   return (
@@ -115,7 +115,7 @@ function Chat({ sendMessage, chatHistory,me='guest' }: {
         {[...chatHistory].reverse().map((x, i) => (
           <div key={i} className="flex gap-2 text-sm">
             <span
-              className={`shrink-0 ${me === x.userName ? 'text-yellow-400/80' : 'text-white/80'} font-semibold `}
+              className={`shrink-0 ${me === x.userName ? 'text-yellow-400/80' : 'text-white/80'} font-semibold`}
             >
               {x.userName}
             </span>

--- a/src/components/exhibition-gallery/threejs/Player.tsx
+++ b/src/components/exhibition-gallery/threejs/Player.tsx
@@ -11,6 +11,7 @@ export default function Player({
   startPos,
   startLookAt,
   circleCollidersRef,
+  sendMove,
 }: {
   size?: number;
   speed: number;
@@ -18,6 +19,7 @@ export default function Player({
   startPos: { x: number; y: number; z: number };
   startLookAt?: { x: number; y: number; z: number };
   circleCollidersRef?: React.RefObject<CircleCollider[]>;
+  sendMove?: (camera: THREE.Camera) => void;
 }) {
   const velocity = useRef(new THREE.Vector3());
   const direction = useRef(new THREE.Vector3());
@@ -33,6 +35,8 @@ export default function Player({
   });
 
   const localPos = useRef(new THREE.Vector3());
+  const prevPos = useRef(new THREE.Vector3(Infinity, Infinity, Infinity));
+  const prevYaw = useRef(Infinity);
 
   const initialized = useRef(false);
 
@@ -96,6 +100,8 @@ export default function Player({
       initialized.current = true;
     }
 
+    if (!document.pointerLockElement) return;
+
     direction.current.set(0, 0, 0);
 
     if (keys.current.w) direction.current.z -= 1;
@@ -156,6 +162,23 @@ export default function Player({
 
     if (!blocked) {
       camera.position.copy(newPos);
+    }
+
+    if (sendMove) {
+      forward.current.set(0, 0, -1).applyQuaternion(camera.quaternion);
+      forward.current.y = 0;
+      forward.current.normalize();
+      const yaw = Math.atan2(forward.current.x, forward.current.z);
+
+      const posMoved =
+        camera.position.distanceToSquared(prevPos.current) > 0.0001;
+      const yawChanged = Math.abs(yaw - prevYaw.current) > 0.01;
+
+      if (posMoved || yawChanged) {
+        prevPos.current.copy(camera.position);
+        prevYaw.current = yaw;
+        sendMove(camera);
+      }
     }
   });
 

--- a/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
+++ b/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
@@ -8,14 +8,13 @@ function RemotePlayer({
   playerInfo,
   remotePlayersRef,
 }: {
-  playerInfo:PlayerInfo
+  playerInfo: PlayerInfo;
   remotePlayersRef: React.RefObject<Map<string, RemotePlayerData>>;
-
 }) {
   const groupRef = useRef<THREE.Group>(null);
   const targetPos = useRef(new THREE.Vector3());
-  const playerId=playerInfo.userId
-  const playerName=playerInfo.userName
+  const playerId = playerInfo.userId;
+  const playerName = playerInfo.userName;
   useFrame(() => {
     const data = remotePlayersRef.current.get(playerId);
     if (!data || !groupRef.current) return;
@@ -35,7 +34,7 @@ function RemotePlayer({
     <group ref={groupRef}>
       {/* 몸통 */}
       <Html position={[0, 1.9, 0]} center>
-        <div className="rounded-full bg-black/50 px-4 py-0.5 w-fit text-lg text-white whitespace-nowrap">
+        <div className="w-fit rounded-full bg-black/50 px-4 py-0.5 text-lg whitespace-nowrap text-white">
           {playerName}
         </div>
       </Html>
@@ -62,7 +61,11 @@ export default function RemotePlayers({
   return (
     <>
       {playerInfo.map((info) => (
-        <RemotePlayer key={info.userId} playerInfo={info} remotePlayersRef={remotePlayersRef} />
+        <RemotePlayer
+          key={info.userId}
+          playerInfo={info}
+          remotePlayersRef={remotePlayersRef}
+        />
       ))}
     </>
   );

--- a/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
+++ b/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
@@ -1,0 +1,69 @@
+import React, { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { PlayerInfo, RemotePlayerData } from '@/hooks/usePlayerSocket';
+import { Html } from '@react-three/drei';
+
+function RemotePlayer({
+  playerInfo,
+  remotePlayersRef,
+}: {
+  playerInfo:PlayerInfo
+  remotePlayersRef: React.RefObject<Map<string, RemotePlayerData>>;
+
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+  const targetPos = useRef(new THREE.Vector3());
+  const playerId=playerInfo.userId
+  const playerName=playerInfo.userName
+  useFrame(() => {
+    const data = remotePlayersRef.current.get(playerId);
+    if (!data || !groupRef.current) return;
+
+    targetPos.current.set(data.x, 0, data.z);
+
+    groupRef.current.position.lerp(targetPos.current, 0.15);
+
+    groupRef.current.rotation.y = THREE.MathUtils.lerp(
+      groupRef.current.rotation.y,
+      data.yaw,
+      0.15
+    );
+  });
+
+  return (
+    <group ref={groupRef}>
+      {/* 몸통 */}
+      <Html position={[0, 1.9, 0]} center>
+        <div className="rounded-full bg-black/50 px-4 py-0.5 w-fit text-lg text-white whitespace-nowrap">
+          {playerName}
+        </div>
+      </Html>
+      <mesh position={[0, 0.7, 0]} castShadow>
+        <capsuleGeometry args={[0.25, 0.8, 4, 8]} />
+        <meshStandardMaterial color="#4a90e2" roughness={0.8} />
+      </mesh>
+      {/* 머리 */}
+      <mesh position={[0, 1.45, 0]} castShadow>
+        <sphereGeometry args={[0.22, 16, 16]} />
+        <meshStandardMaterial color="#f5c5a3" roughness={0.7} />
+      </mesh>
+    </group>
+  );
+}
+
+export default function RemotePlayers({
+  playerInfo,
+  remotePlayersRef,
+}: {
+  playerInfo: PlayerInfo[];
+  remotePlayersRef: React.RefObject<Map<string, RemotePlayerData>>;
+}) {
+  return (
+    <>
+      {playerInfo.map((info) => (
+        <RemotePlayer key={info.userId} playerInfo={info} remotePlayersRef={remotePlayersRef} />
+      ))}
+    </>
+  );
+}

--- a/src/components/exhibition-gallery/threejs/Room.tsx
+++ b/src/components/exhibition-gallery/threejs/Room.tsx
@@ -5,7 +5,6 @@ import { Group, Quaternion, RepeatWrapping, Vector3 } from 'three';
 import { likesToggle } from '@/lib/artwork/service';
 import { useImageDownload } from '@/hooks/useImageDownload';
 
-import { User } from '@supabase/supabase-js';
 import { useRouter } from 'next/navigation';
 import { GalleryUIArtworkProps, WAllType } from '@/types/gallery';
 import { FloorConfig, WallPatternConfig } from '@/types/gallery-theme';
@@ -21,7 +20,7 @@ export default function Room({
   walls,
   innerWalls,
   exhibitionId,
-  user,
+  canLikes,
   floorConfig = defaultPreset.floor,
   wallColor = defaultPreset.wallColor,
   wallPattern,
@@ -32,7 +31,7 @@ export default function Room({
   walls: WAllType[];
   innerWalls: WAllType[];
   exhibitionId: string;
-  user: User | null;
+  canLikes: boolean;
   floorConfig?: FloorConfig;
   wallColor?: string;
   wallPattern?: WallPatternConfig;
@@ -184,11 +183,12 @@ export default function Room({
     };
 
     const handler = (e: KeyboardEvent) => {
+      if (!document.pointerLockElement) return;
       const painting = closestPaintingRef.current;
       if (!painting) return;
 
       if (e.key === '1') {
-        if (!user) return;
+        if (!canLikes) return;
         postLikes();
       }
 
@@ -204,7 +204,7 @@ export default function Room({
     return () => {
       window.removeEventListener('keydown', handler);
     };
-  }, [exhibitionId, user, router, download]);
+  }, [exhibitionId, canLikes, router, download]);
 
   return (
     <>

--- a/src/components/exhibition-gallery/threejs/Scene.tsx
+++ b/src/components/exhibition-gallery/threejs/Scene.tsx
@@ -24,10 +24,7 @@ import Room from './Room';
 import Player from './Player';
 import DynamicDecorations, { CircleCollider } from './DynamicDecorations';
 import RemotePlayers from './RemotePlayers';
-import {
-  RemotePlayerData,
-  PlayerInfo,
-} from '@/hooks/usePlayerSocket';
+import { RemotePlayerData, PlayerInfo } from '@/hooks/usePlayerSocket';
 
 function getGridSize(artworkCount: number): number {
   if (artworkCount <= 4) return 1;
@@ -43,7 +40,7 @@ export default function Scene2({
   preset = defaultPreset,
   sendMove,
   remotePlayersRef,
-  playerInfo
+  playerInfo,
 }: {
   exhibitionId: string;
   ready: Dispatch<SetStateAction<boolean>>;
@@ -70,7 +67,7 @@ export default function Scene2({
         spawnCornerOffset,
         exhibitionId
       ),
-    [roomSize, gridSize, preset.wallColor,exhibitionId]
+    [roomSize, gridSize, preset.wallColor, exhibitionId]
   );
 
   const walls = useMemo(
@@ -226,7 +223,10 @@ export default function Scene2({
         onColliders={handleColliders}
       />
       {remotePlayersRef && playerInfo && (
-        <RemotePlayers playerInfo={playerInfo} remotePlayersRef={remotePlayersRef} />
+        <RemotePlayers
+          playerInfo={playerInfo}
+          remotePlayersRef={remotePlayersRef}
+        />
       )}
       <Player
         startPos={startPosition}
@@ -240,7 +240,7 @@ export default function Scene2({
         speed={3}
         sendMove={sendMove}
       />
-      <PointerLockControls  selector="canvas" />
+      <PointerLockControls selector="canvas" />
     </Canvas>
   );
 }

--- a/src/components/exhibition-gallery/threejs/Scene.tsx
+++ b/src/components/exhibition-gallery/threejs/Scene.tsx
@@ -23,7 +23,11 @@ import { defaultPreset } from '@/lib/gallery/presets';
 import Room from './Room';
 import Player from './Player';
 import DynamicDecorations, { CircleCollider } from './DynamicDecorations';
-import { User } from '@supabase/supabase-js';
+import RemotePlayers from './RemotePlayers';
+import {
+  RemotePlayerData,
+  PlayerInfo,
+} from '@/hooks/usePlayerSocket';
 
 function getGridSize(artworkCount: number): number {
   if (artworkCount <= 4) return 1;
@@ -35,14 +39,20 @@ export default function Scene2({
   exhibitionId,
   ready,
   init,
-  user,
+  canLikes,
   preset = defaultPreset,
+  sendMove,
+  remotePlayersRef,
+  playerInfo
 }: {
   exhibitionId: string;
   ready: Dispatch<SetStateAction<boolean>>;
   init: GalleryUIArtworkProps[];
-  user: User | null;
+  canLikes: boolean;
   preset?: GalleryPreset;
+  sendMove?: (camera: THREE.Camera) => void;
+  remotePlayersRef?: React.RefObject<Map<string, RemotePlayerData>>;
+  playerInfo?: PlayerInfo[];
 }) {
   const height = 9;
   const cellSize = 12;
@@ -57,9 +67,10 @@ export default function Scene2({
         gridSize,
         cellSize,
         preset.wallColor,
-        spawnCornerOffset
+        spawnCornerOffset,
+        exhibitionId
       ),
-    [roomSize, gridSize, preset.wallColor]
+    [roomSize, gridSize, preset.wallColor,exhibitionId]
   );
 
   const walls = useMemo(
@@ -184,7 +195,7 @@ export default function Scene2({
       />
 
       <Room
-        user={user}
+        canLikes={canLikes}
         exhibitionId={exhibitionId}
         size={roomSize}
         height={height}
@@ -204,6 +215,9 @@ export default function Scene2({
         innerWalls={innerWalls}
         onColliders={handleColliders}
       />
+      {remotePlayersRef && playerInfo && (
+        <RemotePlayers playerInfo={playerInfo} remotePlayersRef={remotePlayersRef} />
+      )}
       <Player
         startPos={startPosition}
         startLookAt={{
@@ -214,8 +228,9 @@ export default function Scene2({
         innerWalls={innerWalls}
         circleCollidersRef={circleCollidersRef}
         speed={3}
+        sendMove={sendMove}
       />
-      <PointerLockControls />
+      <PointerLockControls  selector="canvas" />
     </Canvas>
   );
 }

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -17,11 +17,25 @@ export type ChatHistory = { userId: string; userName: string; message: string };
 type OutboundMessage =
   | { type: 'join'; userId: string; userName: string }
   | { type: 'leave'; userId: string }
-  | { type: 'move'; userId: string; x: number; y: number; z: number; yaw: number }
+  | {
+      type: 'move';
+      userId: string;
+      x: number;
+      y: number;
+      z: number;
+      yaw: number;
+    }
   | { type: 'message'; userId: string; message: string };
 
 type InboundMessage =
-  | { type: 'move'; userId: string; x: number; y: number; z: number; yaw: number }
+  | {
+      type: 'move';
+      userId: string;
+      x: number;
+      y: number;
+      z: number;
+      yaw: number;
+    }
   | { type: 'join'; userId: string; userName: string }
   | { type: 'leave'; userId: string }
   | { type: 'message'; userId: string; message: string };
@@ -81,7 +95,12 @@ export function usePlayerSocket(
           { userId: msg.userId, userName: senderName, message: msg.message },
         ]);
       } else if (msg.type === 'join') {
-        remotePlayersRef.current.set(msg.userId, { x: 0, y: 1.6, z: 0, yaw: 0 });
+        remotePlayersRef.current.set(msg.userId, {
+          x: 0,
+          y: 1.6,
+          z: 0,
+          yaw: 0,
+        });
         userNamesRef.current.set(msg.userId, msg.userName);
         setPlayerInfo((prev) =>
           prev.find((p) => p.userId === msg.userId)

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import * as THREE from 'three';
+
+export type SendMoveFn = (camera: THREE.Camera) => void;
+
+export type RemotePlayerData = {
+  x: number;
+  y: number;
+  z: number;
+  yaw: number;
+};
+
+export type PlayerInfo = { userId: string; userName: string };
+
+export type ChatHistory = { userId: string; userName: string; message: string };
+
+type OutboundMessage =
+  | { type: 'join'; userId: string; userName: string }
+  | { type: 'leave'; userId: string }
+  | { type: 'move'; userId: string; x: number; y: number; z: number; yaw: number }
+  | { type: 'message'; userId: string; message: string };
+
+type InboundMessage =
+  | { type: 'move'; userId: string; x: number; y: number; z: number; yaw: number }
+  | { type: 'join'; userId: string; userName: string }
+  | { type: 'leave'; userId: string }
+  | { type: 'message'; userId: string; message: string };
+
+const THROTTLE_MS = 50;
+const _forward = new THREE.Vector3();
+
+export function usePlayerSocket(
+  exhibitionId: string,
+  userId: string | null,
+  userName: string | null
+) {
+  const wsRef = useRef<WebSocket | null>(null);
+  const lastSentAt = useRef(0);
+
+  const remotePlayersRef = useRef<Map<string, RemotePlayerData>>(new Map());
+  const userNamesRef = useRef<Map<string, string>>(new Map());
+
+  const [playerInfo, setPlayerInfo] = useState<PlayerInfo[]>([]);
+  const [chatHistory, setChatHistory] = useState<ChatHistory[]>([]);
+
+  const send = useRef((msg: OutboundMessage) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify(msg));
+  });
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const url = `${process.env.NEXT_PUBLIC_WS_URL}/gallery/${exhibitionId}`;
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      const myName = userName ?? userId;
+      ws.send(JSON.stringify({ type: 'join', userId, userName: myName }));
+      setPlayerInfo([]);
+    };
+
+    ws.onmessage = (e: MessageEvent) => {
+      const msg: InboundMessage = JSON.parse(e.data);
+
+      if (msg.userId === userId) return;
+
+      if (msg.type === 'move') {
+        remotePlayersRef.current.set(msg.userId, {
+          x: msg.x,
+          y: msg.y,
+          z: msg.z,
+          yaw: msg.yaw,
+        });
+      } else if (msg.type === 'message') {
+        const senderName = userNamesRef.current.get(msg.userId) ?? msg.userId;
+        setChatHistory((prev) => [
+          ...prev,
+          { userId: msg.userId, userName: senderName, message: msg.message },
+        ]);
+      } else if (msg.type === 'join') {
+        remotePlayersRef.current.set(msg.userId, { x: 0, y: 1.6, z: 0, yaw: 0 });
+        userNamesRef.current.set(msg.userId, msg.userName);
+        setPlayerInfo((prev) =>
+          prev.find((p) => p.userId === msg.userId)
+            ? prev
+            : [...prev, { userId: msg.userId, userName: msg.userName }]
+        );
+      } else if (msg.type === 'leave') {
+        remotePlayersRef.current.delete(msg.userId);
+        userNamesRef.current.delete(msg.userId);
+        setPlayerInfo((prev) => prev.filter((p) => p.userId !== msg.userId));
+      }
+    };
+
+    ws.onclose = () => {
+      if (wsRef.current === ws) wsRef.current = null;
+    };
+
+    return () => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'leave', userId }));
+      }
+      ws.close();
+    };
+  }, [exhibitionId, userId, userName]);
+
+  const sendMove = useCallback(
+    (camera: THREE.Camera) => {
+      if (!userId) return;
+      const now = Date.now();
+      if (now - lastSentAt.current < THROTTLE_MS) return;
+      lastSentAt.current = now;
+
+      camera.getWorldDirection(_forward);
+
+      send.current({
+        type: 'move',
+        userId,
+        x: camera.position.x,
+        y: camera.position.y,
+        z: camera.position.z,
+        yaw: Math.atan2(_forward.x, _forward.z),
+      });
+    },
+    [userId]
+  );
+
+  const sendMessage = useCallback(
+    (message: string) => {
+      if (!userId) return;
+
+      send.current({ type: 'message', userId, message });
+      setChatHistory((prev) => [
+        ...prev,
+        { userId, userName: userName ?? userId, message },
+      ]);
+    },
+    [userId, userName]
+  );
+
+  return { sendMove, sendMessage, remotePlayersRef, playerInfo, chatHistory };
+}

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -66,6 +66,12 @@ export function usePlayerSocket(
   useEffect(() => {
     if (!userId) return;
 
+    remotePlayersRef.current.clear();
+    userNamesRef.current.clear();
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setChatHistory([]);
+    setPlayerInfo([]);
+
     const url = `${process.env.NEXT_PUBLIC_WS_URL}/gallery/${exhibitionId}`;
     const ws = new WebSocket(url);
     wsRef.current = ws;
@@ -73,7 +79,6 @@ export function usePlayerSocket(
     ws.onopen = () => {
       const myName = userName ?? userId;
       ws.send(JSON.stringify({ type: 'join', userId, userName: myName }));
-      setPlayerInfo([]);
     };
 
     ws.onmessage = (e: MessageEvent) => {

--- a/src/lib/gallery/createWalls.ts
+++ b/src/lib/gallery/createWalls.ts
@@ -1,12 +1,34 @@
 import { Cell, WAllType } from '@/types/gallery';
 
+function hashSeed(str: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = (h * 16777619) >>> 0;
+  }
+  return h;
+}
+
+function makeRng(seed: string) {
+  let s = hashSeed(seed);
+  return () => {
+    s ^= s << 13;
+    s ^= s >> 17;
+    s ^= s << 5;
+    s = s >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
 export function generateGalleryWalls(
   roomSize: number,
   gridSize: number,
   cellSize: number,
   wallColor = '#FFFFFF',
-  spawnCornerOffset = 1.5
+  spawnCornerOffset = 1.5,
+  seed = 'default'
 ) {
+  const rng = makeRng(seed);
   const size = gridSize;
   const half = roomSize / 2;
 
@@ -62,7 +84,7 @@ export function generateGalleryWalls(
     }
     if (neighbors.length) {
       stack.push(current);
-      const next = neighbors[Math.floor(Math.random() * neighbors.length)];
+      const next = neighbors[Math.floor(rng() * neighbors.length)];
       if (next.x > x) {
         current.walls.right = false;
         next.walls.left = false;

--- a/src/lib/gallery/createWalls.ts
+++ b/src/lib/gallery/createWalls.ts
@@ -16,7 +16,7 @@ function makeRng(seed: string) {
     s ^= s >> 17;
     s ^= s << 5;
     s = s >>> 0;
-    return s / 0xffffffff;
+    return s / 0x100000000;
   };
 }
 


### PR DESCRIPTION
## 📌 개요

전시 갤러리에서 여러 사용자가 동시에 접속해 서로의 위치를 확인하고 채팅을 나눌 수 있는 멀티플레이어 기능을 추가했습니다. 또한 전시회별 고유한 갤러리 구조를 위해 시드 기반 벽 생성 방식을 도입했습니다.

## 🔍 변경 사항

> 주요 변경 사항을 설명해주세요.


WebSocket 서버 (server/ws.ts)
- Node.js ws 라이브러리 기반 WebSocket 서버 구현
- /gallery/:exhibitionId URL 경로로 전시회별 독립 룸 관리
- 신규 접속 시 기존 플레이어 상태(위치 + 입장 정보)를 일괄 전송해 동기화
- 비정상 종료(연결 끊김) 시 자동 퇴장 처리 및 나머지 플레이어에게 알림
- 메시지 타입: join / leave / move / message

소켓 클라이언트 훅 (src/hooks/usePlayerSocket.ts)
- WebSocket 연결 생성/해제 및 메시지 송수신 로직 캡슐화
- 이동 데이터 80ms 스로틀링으로 불필요한 네트워크 트래픽 제한
- remotePlayersRef (Map) 로 원격 플레이어 위치 관리 — React 렌더 사이클 밖에서 업데이트해 성능 최적화
- 채팅 히스토리는 React state로 관리해 UI 반응성 확보

원격 플레이어 렌더링 (src/components/exhibition-gallery/threejs/RemotePlayers.tsx)
- 다른 사용자를 캡슐(몸통) + 구(머리) 형태의 3D 캐릭터로 표현
- useFrame에서 lerp 보간으로 부드러운 위치/회전 동기화
- Html 컴포넌트로 플레이어 이름 표시 (Three.js 씬 내부)

채팅 UI (src/components/exhibition-gallery/GalleryHUD.tsx)
- 갤러리 HUD에 채팅창 컴포넌트 추가 (추후 채팅 컴포넌트가 커지면 별도 파일 컴포넌트로 분리예정)
- 채팅 포커스 중 포인터 락 자동 해제 및 키 입력 이벤트 차단
- Enter 키 전송, 한글 조합 중 중복 전송 방지 (isComposing 체크)

시드 기반 벽 생성 (src/lib/gallery/createWalls.ts)
- 전시회 ID를 시드로 활용한 난수 생성
- DFS 미로 알고리즘에 해당 난수 생성기를 적용해 내부 벽 배치 결정
- 동일한 전시회 ID는 항상 동일한 갤러리 레이아웃을 생성 — 서버 저장 없이 모든 클라이언트가 동일한 공간을 가짐

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #155 

## 📸 스크린샷 (UI 변경 시 필수)

> 변경된 UI 스크린샷을 보여주세요.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 소켓 node서버를  render라는 서비스 이용해서 배포했습니다  (배포주소 wss://frontend-8oci.onrender.com)
노션 env 파일에 추가해두었으니 변경 해주시면 됩니다~
