### PR TITLE
[PR] 전시관 VideoTexture 렌더링 버그

### DIFF
--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   Group,
   Mesh,
@@ -19,6 +19,8 @@ const MAT_M = 0.035;
 const FRAME_D = 0.06;
 const MAT_D = 0.035;
 const VIDEO_NEAR_THRESHOLD = 5;
+
+type VideoData = { video: HTMLVideoElement; texture: VideoTexture };
 
 export default function Painting({
   img,
@@ -41,10 +43,12 @@ export default function Painting({
   const meshRef = useRef<Mesh>(null);
   const worldPosRef = useRef(new Vector3());
   const isNearRef = useRef(false);
-  const mountedAtRef = useRef(Date.now());
+  const mountedAtRef = useRef(0);
+  const videoDataRef = useRef<VideoData | null>(null);
 
-  const videoData = useMemo(() => {
-    if (!videoUrl) return null;
+  useEffect(() => {
+    mountedAtRef.current = Date.now();
+    if (!videoUrl) return;
     const video = document.createElement('video');
     video.crossOrigin = 'anonymous';
     video.src = videoUrl;
@@ -54,44 +58,44 @@ export default function Painting({
     video.preload = 'auto';
     const texture = new VideoTexture(video);
     texture.colorSpace = SRGBColorSpace;
-    return { video, texture };
+    videoDataRef.current = { video, texture };
+    video.load();
+    video.play().catch(() => {});
+    return () => {
+      video.pause();
+      texture.dispose();
+      videoDataRef.current = null;
+    };
   }, [videoUrl]);
 
-  useEffect(() => {
-    const v = videoData?.video;
-    if (!v) return;
-    v.load();
-    v.play().catch(() => {});
-    return () => {
-      v.pause();
-      videoData.texture.dispose();
-    };
-  }, [videoData]);
-
   useFrame(({ camera }) => {
-    if (!localRef.current || !videoData || !meshRef.current) return;
+    const videoData = videoDataRef.current;
+    if (!localRef.current || !meshRef.current) return;
     localRef.current.getWorldPosition(worldPosRef.current);
     const near =
       camera.position.distanceTo(worldPosRef.current) < VIDEO_NEAR_THRESHOLD;
-    const videoReady = videoData.video.readyState >= 3;
-    const shouldShow = near && videoReady;
 
-    const warmedUp = Date.now() - mountedAtRef.current > 3000;
-    if (near && videoData.video.paused) {
-      videoData.video.play().catch(() => {});
-    } else if (!near && !videoData.video.paused && warmedUp) {
-      videoData.video.pause();
-    }
+    if (videoData) {
+      const videoReady = videoData.video.readyState >= 3;
+      const shouldShow = near && videoReady;
 
-    if (shouldShow !== isNearRef.current) {
-      isNearRef.current = shouldShow;
-      const mat = meshRef.current.material as MeshStandardMaterial;
-      mat.map = shouldShow ? videoData.texture : img;
-      mat.needsUpdate = true;
-    }
+      const warmedUp = Date.now() - mountedAtRef.current > 3000;
+      if (near && videoData.video.paused) {
+        videoData.video.play().catch(() => {});
+      } else if (!near && !videoData.video.paused && warmedUp) {
+        videoData.video.pause();
+      }
 
-    if (isNearRef.current && videoData.video.readyState >= 2) {
-      videoData.texture.needsUpdate = true;
+      if (shouldShow !== isNearRef.current) {
+        isNearRef.current = shouldShow;
+        const mat = meshRef.current.material as MeshStandardMaterial;
+        mat.map = shouldShow ? videoData.texture : img;
+        mat.needsUpdate = true;
+      }
+
+      if (isNearRef.current && videoData.video.readyState >= 2) {
+        videoData.texture.needsUpdate = true;
+      }
     }
   });
 

--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -1,5 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Group, Texture, Vector3, VideoTexture } from 'three';
+import { useEffect, useMemo, useRef } from 'react';
+import {
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  SRGBColorSpace,
+  Texture,
+  Vector3,
+  VideoTexture,
+} from 'three';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import { Download, Heart } from 'lucide-react';
@@ -30,9 +38,10 @@ export default function Painting({
   videoUrl?: string | null;
 }) {
   const localRef = useRef<Group>(null);
+  const meshRef = useRef<Mesh>(null);
   const worldPosRef = useRef(new Vector3());
   const isNearRef = useRef(false);
-  const [isNear, setIsNear] = useState(false);
+  const mountedAtRef = useRef(Date.now());
 
   const videoData = useMemo(() => {
     if (!videoUrl) return null;
@@ -42,34 +51,51 @@ export default function Painting({
     video.loop = true;
     video.muted = true;
     video.playsInline = true;
-    return { video, texture: new VideoTexture(video) };
+    video.preload = 'auto';
+    const texture = new VideoTexture(video);
+    texture.colorSpace = SRGBColorSpace;
+    return { video, texture };
   }, [videoUrl]);
 
   useEffect(() => {
+    const v = videoData?.video;
+    if (!v) return;
+    v.load();
+    v.play().catch(() => {});
     return () => {
-      videoData?.video.pause();
-      videoData?.texture.dispose();
+      v.pause();
+      videoData.texture.dispose();
     };
   }, [videoData]);
 
   useFrame(({ camera }) => {
-    if (!localRef.current || !videoData) return;
+    if (!localRef.current || !videoData || !meshRef.current) return;
     localRef.current.getWorldPosition(worldPosRef.current);
     const near =
       camera.position.distanceTo(worldPosRef.current) < VIDEO_NEAR_THRESHOLD;
-    if (near !== isNearRef.current) {
-      isNearRef.current = near;
-      setIsNear(near);
-      if (near) {
-        videoData.video.play().catch(() => {});
-      } else {
-        videoData.video.pause();
-      }
+    const videoReady = videoData.video.readyState >= 3;
+    const shouldShow = near && videoReady;
+
+    const warmedUp = Date.now() - mountedAtRef.current > 3000;
+    if (near && videoData.video.paused) {
+      videoData.video.play().catch(() => {});
+    } else if (!near && !videoData.video.paused && warmedUp) {
+      videoData.video.pause();
+    }
+
+    if (shouldShow !== isNearRef.current) {
+      isNearRef.current = shouldShow;
+      const mat = meshRef.current.material as MeshStandardMaterial;
+      mat.map = shouldShow ? videoData.texture : img;
+      mat.needsUpdate = true;
+    }
+
+    if (isNearRef.current && videoData.video.readyState >= 2) {
+      videoData.texture.needsUpdate = true;
     }
   });
 
-  const displayTexture = isNear && videoData ? videoData.texture : img;
-  const [imgW, imgH] = checkImgSize(displayTexture, w, h, 0.4);
+  const [imgW, imgH] = checkImgSize(img, w, h, 0.4);
 
   if (!details) return null;
 
@@ -101,9 +127,9 @@ export default function Painting({
       </mesh>
 
       {/* 작품 이미지 */}
-      <mesh position={[0, 0, imgZ]}>
+      <mesh ref={meshRef} position={[0, 0, imgZ]}>
         <planeGeometry args={[imgW, imgH]} />
-        <meshStandardMaterial map={displayTexture} />
+        <meshStandardMaterial map={img} />
       </mesh>
 
       {/* 작품 정보 */}


### PR DESCRIPTION
## 📌 개요

3D 전시관에서 동영상 변환 작품 접근 시 VideoTexture가 검은 화면으로 표시되거나 색이 뿌옇게 렌더링되는 버그를 수정했습니다.

## 🔍 변경 사항

- `meshRef`를 통한 직접 `material.map` 교체로 React 재조정 우회 -> 텍스처 전환 시 `needsUpdate` 누락 문제 해결

- VideoTexture에 `SRGBColorSpace` 적용 -> sRGB 영상 데이터를 linear로 잘못 해석하던 색감 문제 해결
- 텍스처 전환 시 `texture.needsUpdate`와 `material.needsUpdate` 동시 강제 -> shader recompile과 texture re-upload가 같은 프레임에 처리되도록 보장
- `useFrame`에서 매 프레임 수동 `texture.needsUpdate = true` 설정 -> React StrictMode double-invoke로 인한 `rVFC(requestVideoFrameCallback)` 취소 문제 해결
- 마운트 시 `video.play()` 호출 + 3초 pause 유예로 pre-buffering -> 첫 접근 시 1~2초 딜레이 단축

## 🔗 관련 이슈 번호

close #159 

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경 없음.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- Three.js VideoTexture는 `SRGBColorSpace` 설정 시에 `DECODE_VIDEO_TEXTURE` shader define을 통해 inline sRGB decode를 수행합니다.(`map_fragment.glsl` 참고) 
단, React StrictMode에서 `useEffect cleanup`이 `texture.dispose()`를 호출해 rVFC 체인이 끊기므로, rVFC 의존 없이 `useFrame`에서 직접 `needsUpdate`를 관리합니다.

- useMemo → useEffect + useRef 패턴으로 전환 — React Compiler immutability 규칙 준수