### PR TITLE
[PR] 전시 작품 다건 등록 기능 및 다이얼로그 공통 컴포넌트 추출

### DIFF
--- a/src/app/(exhibitions)/exhibitions/[id]/manage/page.tsx
+++ b/src/app/(exhibitions)/exhibitions/[id]/manage/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   AddWorkDialog,
+  BulkWorkDialog,
   DeleteArtworkDialog,
   EditWorkDialog,
   EndExhibitionDialog,
@@ -91,7 +92,8 @@ export default async function ExhibitionManagePage({ params }: PageProps) {
         )}
 
         {/* 작품 목록 헤더 */}
-        <div className="flex items-center justify-end">
+        <div className="flex items-center justify-end gap-2">
+          <BulkWorkDialog />
           <AddWorkDialog triggerClassName="px-4 py-5 font-bold" />
         </div>
 

--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useFieldArray, useForm, useWatch } from 'react-hook-form';
+import { useParams, useRouter } from 'next/navigation';
+import { useRef, useState } from 'react';
+import Image from 'next/image';
+import { Layers, Loader2, Plus, Upload, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { DialogClose, DialogTrigger } from '@/components/ui/dialog';
+import AppDialog from '@/components/shared/AppDialog';
+import { postArtWorksByExhibitionId } from '@/lib/artwork/service';
+
+type BulkRow = { image: File; title: string; artist_name: string };
+type BulkForm = { rows: BulkRow[] };
+
+const fieldClass =
+  'w-full rounded-lg border border-gray-200 bg-surface px-3 py-2 text-sm outline-none focus:border-[#F5A623] focus:bg-white';
+
+function RowItem({
+  index,
+  fieldId,
+  imageFile,
+  urlCache,
+  onRemove,
+  register,
+}: {
+  index: number;
+  fieldId: string;
+  imageFile: File | undefined;
+  urlCache: React.RefObject<Map<string, string>>;
+  onRemove: () => void;
+  register: ReturnType<typeof useForm<BulkForm>>['register'];
+}) {
+  let preview = '';
+  if (imageFile) {
+    if (!urlCache.current.has(fieldId)) {
+      urlCache.current.set(fieldId, URL.createObjectURL(imageFile));
+    }
+    preview = urlCache.current.get(fieldId)!;
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-white p-3 shadow-[0_1px_4px_rgba(44,40,38,0.06)]">
+      <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-lg bg-[#F5EFE0]">
+        {preview && (
+          <Image
+            src={preview}
+            alt=""
+            fill
+            sizes="64px"
+            className="object-cover"
+          />
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col gap-2">
+        <input
+          {...register(`rows.${index}.title`, { required: true })}
+          placeholder="작품명"
+          className={fieldClass}
+        />
+        <input
+          {...register(`rows.${index}.artist_name`, { required: true })}
+          placeholder="작가명"
+          className={fieldClass}
+        />
+      </div>
+
+      <button
+        type="button"
+        onClick={onRemove}
+        className="flex-shrink-0 rounded-full p-1 text-gray-400 transition-colors hover:text-gray-600"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+export default function BulkWorkDialog() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [result, setResult] = useState<{
+    success: number;
+    fail: number;
+  } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const urlCache = useRef<Map<string, string>>(new Map());
+
+  const {
+    register,
+    control,
+    reset,
+    handleSubmit,
+    formState: { isValid },
+  } = useForm<BulkForm>({
+    mode: 'onChange',
+    defaultValues: { rows: [] },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'rows' });
+  const rowValues = useWatch({ control, name: 'rows' });
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files) return;
+    Array.from(files).forEach((file) => {
+      if (file.type.startsWith('image/')) {
+        append({ image: file, title: '', artist_name: '' });
+      }
+    });
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleRemove = (index: number, fieldId: string) => {
+    const url = urlCache.current.get(fieldId);
+    if (url) {
+      URL.revokeObjectURL(url);
+      urlCache.current.delete(fieldId);
+    }
+    remove(index);
+  };
+
+  const handleClose = useCallback(() => {
+    urlCache.current.forEach((url) => URL.revokeObjectURL(url));
+    urlCache.current.clear();
+    reset();
+    setResult(null);
+  }, [reset]);
+
+  const submitHandler = useCallback(async (data: BulkForm) => {
+    setUploading(true);
+    const results = await Promise.allSettled(
+      data.rows.map((row) => {
+        const formData = new FormData();
+        formData.append('image_url', row.image);
+        formData.append('title', row.title);
+        formData.append('artist_name', row.artist_name);
+        return postArtWorksByExhibitionId(id, formData);
+      })
+    );
+    setUploading(false);
+
+    const success = results.filter((r) => r.status === 'fulfilled').length;
+    const fail = results.filter((r) => r.status === 'rejected').length;
+
+    if (fail === 0) {
+      handleClose();
+      router.refresh();
+    } else {
+      setResult({ success, fail });
+    }
+  }, [id, handleClose, router]);
+
+  const handleOpenChange = useCallback((v: boolean) => {
+    if (!v) handleClose();
+    setOpen(v);
+  }, [handleClose]);
+
+  const trigger = (
+    <DialogTrigger
+      render={
+        <Button variant="outline" className="rounded-xl px-4 py-5 font-bold" />
+      }
+    >
+      <Layers className="h-4 w-4" />
+      여러 개 등록하기
+    </DialogTrigger>
+  );
+
+  return (
+    <AppDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      trigger={trigger}
+      title="작품 여러 개 등록하기"
+      className="max-w-2xl"
+    >
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/gif,image/webp"
+        multiple
+        className="hidden"
+        onChange={(e) => handleFiles(e.target.files)}
+      />
+
+      {fields.length === 0 ? (
+        <div
+          onClick={() => fileInputRef.current?.click()}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            handleFiles(e.dataTransfer.files);
+          }}
+          className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 py-16 transition-colors hover:bg-gray-100"
+        >
+          <Upload className="text-secondary/40 h-8 w-8" />
+          <p className="text-secondary/60 text-sm">
+            이미지를 드래그하거나 클릭하여 여러 장 선택
+          </p>
+          <p className="text-secondary/40 text-xs">JPG, PNG, GIF, WebP 지원</p>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit(submitHandler)}>
+          <div className="space-y-2">
+            {fields.map((field, index) => (
+              <RowItem
+                key={field.id}
+                index={index}
+                fieldId={field.id}
+                imageFile={rowValues[index]?.image}
+                urlCache={urlCache}
+                onRemove={() => handleRemove(index, field.id)}
+                register={register}
+              />
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="text-secondary/60 hover:text-secondary mt-3 w-full rounded-xl border border-dashed border-gray-200 py-3 text-sm transition-colors hover:bg-gray-50"
+          >
+            <Plus className="mr-1 inline h-3.5 w-3.5" />
+            이미지 추가
+          </button>
+
+          {result && (
+            <p className="mt-2 text-sm text-red-500">
+              {result.success}개 성공, {result.fail}개 실패. 실패한 항목을
+              확인해주세요.
+            </p>
+          )}
+
+          <div className="mt-4 flex gap-2">
+            <Button
+              type="submit"
+              disabled={!isValid || uploading}
+              className="flex-1 rounded-xl py-6"
+            >
+              {uploading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  등록중...
+                </>
+              ) : (
+                `${fields.length}개 등록하기`
+              )}
+            </Button>
+            <DialogClose
+              render={
+                <Button variant="outline" className="rounded-xl px-6 py-6" />
+              }
+            >
+              취소
+            </DialogClose>
+          </div>
+        </form>
+      )}
+    </AppDialog>
+  );
+}

--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { useParams, useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
@@ -19,26 +19,25 @@ const fieldClass =
 
 function RowItem({
   index,
-  fieldId,
   imageFile,
-  urlCache,
   onRemove,
   register,
 }: {
   index: number;
-  fieldId: string;
   imageFile: File | undefined;
-  urlCache: React.RefObject<Map<string, string>>;
   onRemove: () => void;
   register: ReturnType<typeof useForm<BulkForm>>['register'];
 }) {
-  let preview = '';
-  if (imageFile) {
-    if (!urlCache.current.has(fieldId)) {
-      urlCache.current.set(fieldId, URL.createObjectURL(imageFile));
-    }
-    preview = urlCache.current.get(fieldId)!;
-  }
+  const preview = useMemo(
+    () => (imageFile ? URL.createObjectURL(imageFile) : ''),
+    [imageFile]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (preview) URL.revokeObjectURL(preview);
+    };
+  }, [preview]);
 
   return (
     <div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-white p-3 shadow-[0_1px_4px_rgba(44,40,38,0.06)]">
@@ -88,7 +87,6 @@ export default function BulkWorkDialog() {
     fail: number;
   } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const urlCache = useRef<Map<string, string>>(new Map());
 
   const {
     register,
@@ -114,18 +112,9 @@ export default function BulkWorkDialog() {
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const handleRemove = (index: number, fieldId: string) => {
-    const url = urlCache.current.get(fieldId);
-    if (url) {
-      URL.revokeObjectURL(url);
-      urlCache.current.delete(fieldId);
-    }
-    remove(index);
-  };
+  const handleRemove = (index: number) => remove(index);
 
   const handleClose = useCallback(() => {
-    urlCache.current.forEach((url) => URL.revokeObjectURL(url));
-    urlCache.current.clear();
     reset();
     setResult(null);
   }, [reset]);
@@ -225,10 +214,8 @@ export default function BulkWorkDialog() {
               <RowItem
                 key={field.id}
                 index={index}
-                fieldId={field.id}
                 imageFile={rowValues[index]?.image}
-                urlCache={urlCache}
-                onRemove={() => handleRemove(index, field.id)}
+                onRemove={() => handleRemove(index)}
                 register={register}
               />
             ))}

--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -141,10 +141,12 @@ export default function BulkWorkDialog() {
         setOpen(false);
         router.refresh();
       } else {
+        const failedRows = data.rows.filter((_, i) => results[i].status === 'rejected');
+        reset({ rows: failedRows });
         setResult({ success, fail });
       }
     },
-    [id, handleClose, router]
+    [id, handleClose, reset, router]
   );
 
   const onSubmit = useCallback(

--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -130,39 +130,48 @@ export default function BulkWorkDialog() {
     setResult(null);
   }, [reset]);
 
-  const submitHandler = useCallback(async (data: BulkForm) => {
-    setUploading(true);
-    const results = await Promise.allSettled(
-      data.rows.map((row) => {
-        const formData = new FormData();
-        formData.append('image_url', row.image);
-        formData.append('title', row.title);
-        formData.append('artist_name', row.artist_name);
-        return postArtWorksByExhibitionId(id, formData);
-      })
-    );
-    setUploading(false);
+  const submitHandler = useCallback(
+    async (data: BulkForm) => {
+      setUploading(true);
+      const results = await Promise.allSettled(
+        data.rows.map((row) => {
+          const formData = new FormData();
+          formData.append('image_url', row.image);
+          formData.append('title', row.title);
+          formData.append('artist_name', row.artist_name);
+          return postArtWorksByExhibitionId(id, formData);
+        })
+      );
+      setUploading(false);
 
-    const success = results.filter((r) => r.status === 'fulfilled').length;
-    const fail = results.filter((r) => r.status === 'rejected').length;
+      const success = results.filter((r) => r.status === 'fulfilled').length;
+      const fail = results.filter((r) => r.status === 'rejected').length;
 
-    if (fail === 0) {
-      handleClose();
-      router.refresh();
-    } else {
-      setResult({ success, fail });
-    }
-  }, [id, handleClose, router]);
+      if (fail === 0) {
+        handleClose();
+        router.refresh();
+      } else {
+        setResult({ success, fail });
+      }
+    },
+    [id, handleClose, router]
+  );
 
-  const handleOpenChange = useCallback((v: boolean) => {
-    if (!v) handleClose();
-    setOpen(v);
-  }, [handleClose]);
+  const handleOpenChange = useCallback(
+    (v: boolean) => {
+      if (!v) handleClose();
+      setOpen(v);
+    },
+    [handleClose]
+  );
 
   const trigger = (
     <DialogTrigger
       render={
-        <Button variant="outline" className="rounded-xl px-4 py-5 font-bold" />
+        <Button
+          variant="white"
+          className="rounded-xl px-4 py-5 font-bold"
+        />
       }
     >
       <Layers className="h-4 w-4" />

--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -158,6 +158,11 @@ export default function BulkWorkDialog() {
     [id, handleClose, router]
   );
 
+  const onSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => handleSubmit(submitHandler)(e),
+    [handleSubmit, submitHandler]
+  );
+
   const handleOpenChange = useCallback(
     (v: boolean) => {
       if (!v) handleClose();
@@ -214,7 +219,7 @@ export default function BulkWorkDialog() {
           <p className="text-secondary/40 text-xs">JPG, PNG, GIF, WebP 지원</p>
         </div>
       ) : (
-        <form onSubmit={handleSubmit(submitHandler)}>
+        <form onSubmit={onSubmit}>
           <div className="space-y-2">
             {fields.map((field, index) => (
               <RowItem

--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -141,7 +141,9 @@ export default function BulkWorkDialog() {
         setOpen(false);
         router.refresh();
       } else {
-        const failedRows = data.rows.filter((_, i) => results[i].status === 'rejected');
+        const failedRows = data.rows.filter(
+          (_, i) => results[i].status === 'rejected'
+        );
         reset({ rows: failedRows });
         setResult({ success, fail });
       }
@@ -165,10 +167,7 @@ export default function BulkWorkDialog() {
   const trigger = (
     <DialogTrigger
       render={
-        <Button
-          variant="white"
-          className="rounded-xl px-4 py-5 font-bold"
-        />
+        <Button variant="white" className="rounded-xl px-4 py-5 font-bold" />
       }
     >
       <Layers className="h-4 w-4" />

--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -149,6 +149,7 @@ export default function BulkWorkDialog() {
 
       if (fail === 0) {
         handleClose();
+        setOpen(false);
         router.refresh();
       } else {
         setResult({ success, fail });

--- a/src/components/exhibition/manage/WorkDialog.tsx
+++ b/src/components/exhibition/manage/WorkDialog.tsx
@@ -4,14 +4,8 @@ import { Pencil, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import WorkFormBox from './WorkFormBox';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
+import { DialogClose, DialogTrigger } from '@/components/ui/dialog';
+import AppDialog from '@/components/shared/AppDialog';
 import ImageUploadBox from '@/components/shared/ImageUploadBox';
 import { Controller, useForm } from 'react-hook-form';
 import { useParams, useRouter } from 'next/navigation';
@@ -113,127 +107,127 @@ export default function WorkDialog(props: WorkDialogProps) {
     }
   }, [open, work, reset]);
 
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger
-        render={
-          work ? (
-            <Button
-              size="sm"
-              variant="surface"
-              className="hover:text-primary flex-1 rounded-lg"
-            />
-          ) : (
-            <Button className={cn('rounded-xl', addTriggerClassName)} />
-          )
-        }
-      >
-        {work ? (
-          <>
-            <Pencil className="h-3.5 w-3.5" />
-            수정
-          </>
+  const trigger = (
+    <DialogTrigger
+      render={
+        work ? (
+          <Button
+            size="sm"
+            variant="surface"
+            className="hover:text-primary flex-1 rounded-lg"
+          />
         ) : (
-          <>
-            <Plus className="h-4 w-4" />
-            {addTriggerLabel}
-          </>
-        )}
-      </DialogTrigger>
+          <Button className={cn('rounded-xl hover:bg-primary/80', addTriggerClassName)} />
+        )
+      }
+    >
+      {work ? (
+        <>
+          <Pencil className="h-3.5 w-3.5" />
+          수정
+        </>
+      ) : (
+        <>
+          <Plus className="h-4 w-4" />
+          {addTriggerLabel}
+        </>
+      )}
+    </DialogTrigger>
+  );
 
-      <DialogContent className="max-h-[90vh] w-[calc(100%-2rem)] max-w-xl overflow-y-auto sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle className="text-secondary text-lg font-bold">
-            {work ? '작품 수정' : '작품 등록'}
-          </DialogTitle>
-        </DialogHeader>
+  return (
+    <AppDialog
+      open={open}
+      onOpenChange={setOpen}
+      trigger={trigger}
+      title={work ? '작품 수정' : '작품 등록'}
+      className="sm:max-w-lg"
+    >
+      <form onSubmit={handleSubmit(submitHandler)}>
+        <div className="space-y-5 py-1">
+          <Controller
+            name="image_url"
+            control={control}
+            rules={{ required: true }}
+            render={({ field }) => (
+              <WorkFormBox label="작품 이미지" essential>
+                <ImageUploadBox
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              </WorkFormBox>
+            )}
+          />
 
-        <form onSubmit={handleSubmit(submitHandler)}>
-          <div className="space-y-5 py-1">
-            <Controller
-              name="image_url"
-              control={control}
-              rules={{ required: true }}
-              render={({ field }) => (
-                <WorkFormBox label="작품 이미지" essential>
-                  <ImageUploadBox
-                    value={field.value}
-                    onChange={field.onChange}
-                  />
-                </WorkFormBox>
-              )}
+          <WorkFormBox label="작품명" essential>
+            <input
+              {...register('title', { required: true })}
+              type="text"
+              placeholder="작품 제목을 입력하세요"
+              className={fieldClass}
             />
+          </WorkFormBox>
 
-            <WorkFormBox label="작품명" essential>
-              <input
-                {...register('title', { required: true })}
-                type="text"
-                placeholder="작품 제목을 입력하세요"
-                className={fieldClass}
-              />
-            </WorkFormBox>
+          <WorkFormBox label="작가명" essential>
+            <input
+              {...register('artist_name', { required: true })}
+              type="text"
+              placeholder="학생 이름"
+              className={fieldClass}
+            />
+          </WorkFormBox>
 
-            <WorkFormBox label="작가명" essential>
-              <input
-                {...register('artist_name', { required: true })}
-                type="text"
-                placeholder="학생 이름"
-                className={fieldClass}
-              />
-            </WorkFormBox>
-
-            <WorkFormBox
-              label={
-                <>
-                  작가 이메일{' '}
-                  <span className="text-secondary/50 font-normal">(선택)</span>
-                </>
-              }
-            >
-              <input
-                {...register('artist_email', { required: false })}
-                type="email"
-                placeholder="스타아트 가입 이메일 (있는 경우)"
-                className={fieldClass}
-              />
-              {errors.artist_email && (
-                <p className="text-xs text-red-500">
-                  {errors.artist_email.message}
-                </p>
-              )}
-              <p className="text-secondary/50 text-xs">
-                입력 시 해당 계정의 &apos;내 작품 모아보기&apos;에 표시됩니다
+          <WorkFormBox
+            label={
+              <>
+                작가 이메일{' '}
+                <span className="text-secondary/50 font-normal">(선택)</span>
+              </>
+            }
+          >
+            <input
+              {...register('artist_email', { required: false })}
+              type="email"
+              placeholder="스타아트 가입 이메일 (있는 경우)"
+              className={fieldClass}
+            />
+            {errors.artist_email && (
+              <p className="text-xs text-red-500">
+                {errors.artist_email.message}
               </p>
-            </WorkFormBox>
+            )}
+            <p className="text-secondary/50 text-xs">
+              입력 시 해당 계정의 &apos;내 작품 모아보기&apos;에 표시됩니다
+            </p>
+          </WorkFormBox>
 
-            <WorkFormBox label="작품 설명">
-              <textarea
-                {...register('description')}
-                placeholder="작품에 대한 이야기를 담아주세요..."
-                rows={4}
-                className={`${fieldClass} resize-none`}
-              />
-            </WorkFormBox>
-          </div>
+          <WorkFormBox label="작품 설명">
+            <textarea
+              {...register('description')}
+              placeholder="작품에 대한 이야기를 담아주세요..."
+              rows={4}
+              className={`${fieldClass} resize-none`}
+            />
+          </WorkFormBox>
+        </div>
 
-          <div className="flex gap-2 pt-2">
-            <Button
-              type="submit"
-              disabled={!isValid || isSubmitting}
-              className="flex-1 rounded-xl py-6"
-            >
-              {work ? '수정하기' : isSubmitting ? '등록중' : '등록하기'}
-            </Button>
-            <DialogClose
-              render={
-                <Button variant="outline" className="rounded-xl px-6 py-6" />
-              }
-            >
-              취소
-            </DialogClose>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+        <div className="flex gap-2 pt-2">
+          <Button
+            type="submit"
+            disabled={!isValid || isSubmitting}
+            className="flex-1 rounded-xl py-6"
+          >
+            {work ? '수정하기' : isSubmitting ? '등록중' : '등록하기'}
+          </Button>
+          <DialogClose
+            render={
+              <Button variant="outline" className="rounded-xl px-6 py-6" />
+            }
+          >
+            취소
+          </DialogClose>
+        </div>
+      </form>
+    </AppDialog>
   );
 }

--- a/src/components/exhibition/manage/WorkDialog.tsx
+++ b/src/components/exhibition/manage/WorkDialog.tsx
@@ -117,7 +117,12 @@ export default function WorkDialog(props: WorkDialogProps) {
             className="hover:text-primary flex-1 rounded-lg"
           />
         ) : (
-          <Button className={cn('rounded-xl hover:bg-primary/80', addTriggerClassName)} />
+          <Button
+            className={cn(
+              'hover:bg-primary/80 rounded-xl',
+              addTriggerClassName
+            )}
+          />
         )
       }
     >
@@ -151,10 +156,7 @@ export default function WorkDialog(props: WorkDialogProps) {
             rules={{ required: true }}
             render={({ field }) => (
               <WorkFormBox label="작품 이미지" essential>
-                <ImageUploadBox
-                  value={field.value}
-                  onChange={field.onChange}
-                />
+                <ImageUploadBox value={field.value} onChange={field.onChange} />
               </WorkFormBox>
             )}
           />

--- a/src/components/exhibition/manage/index.ts
+++ b/src/components/exhibition/manage/index.ts
@@ -1,6 +1,7 @@
 // 작품 추가, 수정버튼 dialog
 export { default as EditWorkDialog } from './EditWorkDialog';
 export { default as AddWorkDialog } from './AddWorkDialog';
+export { default as BulkWorkDialog } from './BulkWorkDialog';
 
 // 작품 삭제, 전시회 종료 alert dialog
 export { default as DeleteArtworkDialog } from './DeleteArtworkDialog';

--- a/src/components/my-page/ProfileEditDialog.tsx
+++ b/src/components/my-page/ProfileEditDialog.tsx
@@ -3,15 +3,9 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Pencil } from 'lucide-react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  DialogFooter,
-} from '@/components/ui/dialog';
+import { DialogTrigger } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import AppDialog from '@/components/shared/AppDialog';
 import type { Profile } from '@/types/profile';
 
 interface Props {
@@ -63,66 +57,68 @@ export default function ProfileEditDialog({ profile }: Props) {
     }
   }
 
+  const trigger = (
+    <DialogTrigger
+      render={
+        <button
+          className="rounded-full p-1.5 text-[#a09a92] transition-colors hover:bg-[#f5efe6] hover:text-[#7a6e65]"
+          aria-label="프로필 편집"
+        />
+      }
+    >
+      <Pencil size={15} />
+    </DialogTrigger>
+  );
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger
-        render={
-          <button className="rounded-full p-1.5 text-[#a09a92] transition-colors hover:bg-[#f5efe6] hover:text-[#7a6e65]" />
-        }
-        aria-label="프로필 편집"
-      >
-        <Pencil size={15} />
-      </DialogTrigger>
+    <AppDialog
+      open={open}
+      onOpenChange={setOpen}
+      trigger={trigger}
+      title="프로필 수정"
+      className="max-w-sm"
+    >
+      <div className="space-y-3 py-1">
+        <div>
+          <label className="mb-1.5 block text-[13px] font-medium text-[#5a534c]">
+            이름
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded-[12px] border border-[#e8e1d7] bg-[#faf7f2] px-4 py-2.5 text-[14px] text-[#26221f] outline-none focus:border-[#f1c792] focus:ring-2 focus:ring-[#f1c792]/30"
+            placeholder="이름을 입력하세요"
+          />
+        </div>
 
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle className="text-[16px] font-bold text-[#26221f]">
-            프로필 수정
-          </DialogTitle>
-        </DialogHeader>
-
-        <div className="space-y-3 py-1">
+        {profile.role === 'teacher' && (
           <div>
             <label className="mb-1.5 block text-[13px] font-medium text-[#5a534c]">
-              이름
+              학원명
             </label>
             <input
               type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
+              value={institution}
+              onChange={(e) => setInstitution(e.target.value)}
               className="w-full rounded-[12px] border border-[#e8e1d7] bg-[#faf7f2] px-4 py-2.5 text-[14px] text-[#26221f] outline-none focus:border-[#f1c792] focus:ring-2 focus:ring-[#f1c792]/30"
-              placeholder="이름을 입력하세요"
+              placeholder="학원명을 입력하세요"
             />
           </div>
+        )}
 
-          {profile.role === 'teacher' && (
-            <div>
-              <label className="mb-1.5 block text-[13px] font-medium text-[#5a534c]">
-                학원명
-              </label>
-              <input
-                type="text"
-                value={institution}
-                onChange={(e) => setInstitution(e.target.value)}
-                className="w-full rounded-[12px] border border-[#e8e1d7] bg-[#faf7f2] px-4 py-2.5 text-[14px] text-[#26221f] outline-none focus:border-[#f1c792] focus:ring-2 focus:ring-[#f1c792]/30"
-                placeholder="학원명을 입력하세요"
-              />
-            </div>
-          )}
+        {error && <p className="text-[12px] text-red-500">{error}</p>}
+      </div>
 
-          {error && <p className="text-[12px] text-red-500">{error}</p>}
-        </div>
-
-        <DialogFooter>
-          <Button
-            onClick={handleSubmit}
-            disabled={loading}
-            className="w-full rounded-[12px] bg-[#f0b63b] text-white hover:bg-[#e2a93a] disabled:opacity-60"
-          >
-            {loading ? '저장 중...' : '저장'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <div className="pt-3">
+        <Button
+          onClick={handleSubmit}
+          disabled={loading}
+          className="w-full rounded-[12px] bg-[#f0b63b] text-white hover:bg-[#e2a93a] disabled:opacity-60"
+        >
+          {loading ? '저장 중...' : '저장'}
+        </Button>
+      </div>
+    </AppDialog>
   );
 }

--- a/src/components/shared/AppDialog.tsx
+++ b/src/components/shared/AppDialog.tsx
@@ -7,10 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import {
-  DIALOG_CARD_CLASS,
-  DIALOG_OVERLAY_CLASS,
-} from '@/lib/styles/dialog';
+import { DIALOG_CARD_CLASS, DIALOG_OVERLAY_CLASS } from '@/lib/styles/dialog';
 
 interface AppDialogProps {
   open: boolean;

--- a/src/components/shared/AppDialog.tsx
+++ b/src/components/shared/AppDialog.tsx
@@ -34,7 +34,7 @@ export default function AppDialog({
       {trigger}
       <DialogContent
         className={cn(
-          'max-h-[90vh] w-[calc(100%-2rem)] max-w-lg overflow-y-auto p-0!',
+          'w-[calc(100%-2rem)] max-w-lg overflow-hidden p-0!',
           DIALOG_CARD_CLASS,
           className
         )}
@@ -42,14 +42,16 @@ export default function AppDialog({
         showCloseButton={false}
         initialFocus={false}
       >
-        <div className="px-6 pt-6 pb-2">
-          <DialogHeader>
-            <DialogTitle className="text-secondary text-lg font-bold">
-              {title}
-            </DialogTitle>
-          </DialogHeader>
+        <div className="max-h-[90vh] overflow-y-auto">
+          <div className="px-6 pt-6 pb-2">
+            <DialogHeader>
+              <DialogTitle className="text-secondary text-lg font-bold">
+                {title}
+              </DialogTitle>
+            </DialogHeader>
+          </div>
+          <div className="px-6 pb-6">{children}</div>
         </div>
-        <div className="px-6 pb-6">{children}</div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/shared/AppDialog.tsx
+++ b/src/components/shared/AppDialog.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import {
   Dialog,
@@ -30,14 +29,6 @@ export default function AppDialog({
   children,
   className,
 }: AppDialogProps) {
-  useEffect(() => {
-    if (!open) return;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [open]);
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {trigger}

--- a/src/components/shared/AppDialog.tsx
+++ b/src/components/shared/AppDialog.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  DIALOG_CARD_CLASS,
+  DIALOG_OVERLAY_CLASS,
+} from '@/lib/styles/dialog';
+
+interface AppDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function AppDialog({
+  open,
+  onOpenChange,
+  trigger,
+  title,
+  children,
+  className,
+}: AppDialogProps) {
+  useEffect(() => {
+    if (!open) return;
+    const scrollY = window.scrollY;
+    document.body.style.overflow = 'hidden';
+    // base-ui가 포커스 이동 시 스크롤되는 것 방지
+    const raf = requestAnimationFrame(() => window.scrollTo(0, scrollY));
+    return () => {
+      cancelAnimationFrame(raf);
+      document.body.style.overflow = '';
+      window.scrollTo(0, scrollY);
+    };
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {trigger}
+      <DialogContent
+        className={cn(
+          'max-h-[90vh] w-[calc(100%-2rem)] max-w-lg overflow-y-auto p-0!',
+          DIALOG_CARD_CLASS,
+          className
+        )}
+        overlayClassName={DIALOG_OVERLAY_CLASS}
+        showCloseButton={false}
+      >
+        <div className="px-6 pt-6 pb-2">
+          <DialogHeader>
+            <DialogTitle className="text-secondary text-lg font-bold">
+              {title}
+            </DialogTitle>
+          </DialogHeader>
+        </div>
+        <div className="px-6 pb-6">{children}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/shared/AppDialog.tsx
+++ b/src/components/shared/AppDialog.tsx
@@ -32,14 +32,9 @@ export default function AppDialog({
 }: AppDialogProps) {
   useEffect(() => {
     if (!open) return;
-    const scrollY = window.scrollY;
     document.body.style.overflow = 'hidden';
-    // base-ui가 포커스 이동 시 스크롤되는 것 방지
-    const raf = requestAnimationFrame(() => window.scrollTo(0, scrollY));
     return () => {
-      cancelAnimationFrame(raf);
       document.body.style.overflow = '';
-      window.scrollTo(0, scrollY);
     };
   }, [open]);
 
@@ -54,6 +49,7 @@ export default function AppDialog({
         )}
         overlayClassName={DIALOG_OVERLAY_CLASS}
         showCloseButton={false}
+        initialFocus={false}
       >
         <div className="px-6 pt-6 pb-2">
           <DialogHeader>

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -69,11 +69,17 @@ export default function ArtworkDetailContent({
 
   return (
     <div
-      className={cn('fixed top-0 left-0 bottom-0 w-screen z-50 flex items-center justify-center px-4', DIALOG_OVERLAY_CLASS)}
+      className={cn(
+        'fixed top-0 bottom-0 left-0 z-50 flex w-screen items-center justify-center px-4',
+        DIALOG_OVERLAY_CLASS
+      )}
       onClick={onClose}
     >
       <div
-        className={cn(DIALOG_CARD_CLASS, 'relative max-w-132.5 overflow-hidden')}
+        className={cn(
+          DIALOG_CARD_CLASS,
+          'relative max-w-132.5 overflow-hidden'
+        )}
         onClick={(e) => e.stopPropagation()}
       >
         {/* 닫기 버튼 */}

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -73,7 +73,7 @@ export default function ArtworkDetailContent({
       onClick={onClose}
     >
       <div
-        className={cn(DIALOG_CARD_CLASS, 'max-w-132.5 overflow-hidden')}
+        className={cn(DIALOG_CARD_CLASS, 'relative max-w-132.5 overflow-hidden')}
         onClick={(e) => e.stopPropagation()}
       >
         {/* 닫기 버튼 */}

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -2,6 +2,8 @@
 
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { DIALOG_CARD_CLASS, DIALOG_OVERLAY_CLASS } from '@/lib/styles/dialog';
 
 export interface ArtworkDetailContentProps {
   image: string;
@@ -67,11 +69,11 @@ export default function ArtworkDetailContent({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      className={cn('fixed inset-0 z-50 flex items-center justify-center px-4', DIALOG_OVERLAY_CLASS)}
       onClick={onClose}
     >
       <div
-        className="relative w-full max-w-132.5 overflow-hidden rounded-3xl shadow-2xl"
+        className={cn(DIALOG_CARD_CLASS, 'max-w-132.5 overflow-hidden')}
         onClick={(e) => e.stopPropagation()}
       >
         {/* 닫기 버튼 */}

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -69,7 +69,7 @@ export default function ArtworkDetailContent({
 
   return (
     <div
-      className={cn('fixed inset-0 z-50 flex items-center justify-center px-4', DIALOG_OVERLAY_CLASS)}
+      className={cn('fixed top-0 left-0 bottom-0 w-screen z-50 flex items-center justify-center px-4', DIALOG_OVERLAY_CLASS)}
       onClick={onClose}
     >
       <div

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,6 +21,8 @@ const buttonVariants = cva(
           'bg-destructive/5 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 border-destructive/20 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
         link: 'text-primary underline-offset-4 hover:underline',
         'on-primary': 'bg-white text-primary hover:bg-white/90 shadow-sm',
+        white:
+          'border-transparent bg-white text-secondary/60 hover:bg-primary/10 hover:text-secondary',
         primaryGhost:
           'hover:bg-white hover:text-primary aria-expanded:bg-white aria-expanded:text-primary dark:hover:bg-white/50',
       },

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -43,13 +43,15 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  overlayClassName,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
+  overlayClassName?: string;
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed top-0 left-0 bottom-0 w-screen isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs',
+        'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed top-0 bottom-0 left-0 isolate z-50 w-screen bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs',
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs',
+        'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed top-0 left-0 bottom-0 w-screen isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs',
         className
       )}
       {...props}

--- a/src/lib/styles/dialog.ts
+++ b/src/lib/styles/dialog.ts
@@ -1,2 +1,2 @@
 export const DIALOG_OVERLAY_CLASS = 'bg-black/50 supports-backdrop-filter:backdrop-blur-none';
-export const DIALOG_CARD_CLASS = 'relative w-full rounded-3xl shadow-2xl';
+export const DIALOG_CARD_CLASS = 'w-full rounded-3xl shadow-2xl';

--- a/src/lib/styles/dialog.ts
+++ b/src/lib/styles/dialog.ts
@@ -1,0 +1,2 @@
+export const DIALOG_OVERLAY_CLASS = 'bg-black/50 supports-backdrop-filter:backdrop-blur-none';
+export const DIALOG_CARD_CLASS = 'relative w-full rounded-3xl shadow-2xl';

--- a/src/lib/styles/dialog.ts
+++ b/src/lib/styles/dialog.ts
@@ -1,2 +1,3 @@
-export const DIALOG_OVERLAY_CLASS = 'bg-black/50 supports-backdrop-filter:backdrop-blur-none';
+export const DIALOG_OVERLAY_CLASS =
+  'bg-black/50 supports-backdrop-filter:backdrop-blur-none';
 export const DIALOG_CARD_CLASS = 'w-full rounded-3xl shadow-2xl';


### PR DESCRIPTION
## 📌 개요

선생님이 작품을 한 번에 여러 개 등록할 수 있는 다건 등록 기능을 추가했습니다.
또한 여러 다이얼로그에 반복되던 오버레이/카드 스타일을 AppDialog 공통 컴포넌트로 통일했습니다.

## 🔍 변경 사항

- 작품 다건 등록 기능 추가 (이미지 다중 선택/드래그&드롭 → 작품명·작가명 일괄 입력 → 병렬 업로드)

- AppDialog 래퍼 컴포넌트 추가 (dark overlay + rounded-3xl 카드 스타일 공통화)
- DIALOG_OVERLAY_CLASS, DIALOG_CARD_CLASS 스타일 상수 추출
- WorkDialog, ProfileEditDialog를 AppDialog로 교체
- ArtworkDetailContent 오버레이/카드 스타일을 공통 상수로 통일
- 다이얼로그 열릴 때 scroll jump 방지 (initialFocus={false})
- 업로드 성공 후 scroll lock 해제 안 되는 버그 수정

## 🔗 관련 이슈 번호

close #157 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1503" height="753" alt="스크린샷 2026-06-09 오후 3 45 24" src="https://github.com/user-attachments/assets/3cddb6e2-6e96-4549-bdb5-6ccfd01322f6" />
<img width="1503" height="753" alt="스크린샷 2026-06-09 오후 3 45 52" src="https://github.com/user-attachments/assets/d89ee780-2b14-4eaf-89ca-0d827fb77508" />
<img width="1503" height="753" alt="스크린샷 2026-06-09 오후 3 47 00" src="https://github.com/user-attachments/assets/21bdad06-8955-4985-9718-b126c00c8a37" />
<img width="1503" height="753" alt="스크린샷 2026-06-09 오후 3 47 08" src="https://github.com/user-attachments/assets/13589ccb-3b5e-48c8-9e85-800f97b081f5" />

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- 다건 등록은 기존 단건 POST API를 Promise.allSettled로 병렬 호출하는 방식
- 일부 실패 시 성공/실패 개수 표시 후 재시도 가능
- AppDialog의 initialFocus={false}는 base-ui 포커스 이동 시 발생하는 scroll jump 방지용
- scroll lock 버그: base-ui가 내부적으로 useScrollLock 사용 중 → 커스텀 overflow:hidden 코드가 "원본 스타일"로 저장되어 unlock 시 복원 → 커스텀 코드 전부 제거로 해결
