### PR TITLE
[PR] 마이페이지 전시회 썸네일 Image 비율 경고 수정

### DIFF
--- a/src/components/my-page/ExhibitionList.tsx
+++ b/src/components/my-page/ExhibitionList.tsx
@@ -83,13 +83,15 @@ export default function ExhibitionList({ exhibitions }: ExhibitionListProps) {
                   idx > 0 ? 'mt-1' : ''
                 }`}
               >
-                <Image
-                  src={ex.thumbnail || '/images/default_thumb.jpg'}
-                  alt=""
-                  width={44}
-                  height={44}
-                  className="shrink-0 rounded-[14px] object-cover"
-                />
+                <div className="relative h-11 w-11 shrink-0 overflow-hidden rounded-[14px]">
+                  <Image
+                    src={ex.thumbnail || '/images/default_thumb.jpg'}
+                    alt=""
+                    fill
+                    className="object-cover"
+                    sizes="44px"
+                  />
+                </div>
 
                 <div className="min-w-0 flex-1">
                   <p className="mb-1 text-[14px] font-semibold text-[#2b2724]">


### PR DESCRIPTION
## 📌 개요

마이페이지 전시회 목록의 썸네일 이미지에서 Next.js Image 컴포넌트
aspect ratio 경고가 반복 출력되는 문제를 수정합니다.

## 🔍 변경 사항

- ExhibitionList.tsx: 썸네일 Image를 `width/height` 속성 방식에서 `fill` + 고정 크기 컨테이너 방식으로 변경

## 🔗 관련 이슈 번호

close #164 

## 📸 스크린샷 (UI 변경 시 필수)

> UI 변화 없음.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

Tailwind Preflight의 `img { height: auto }` 규칙이 HTML height 속성을 덮어써 발생하는 구조적 문제였습니다.
`fill` 방식은 컨테이너가 크기를 담당하므로 동일한 문제가 재발하지 않습니다.
