### PR TITLE
[PR] 전시관 카툰 캐릭터 추가 및 채팅 히스토리 보존

### DIFF
--- a/server/ws.ts
+++ b/server/ws.ts
@@ -3,7 +3,7 @@ import { IncomingMessage } from 'http';
 
 const PORT = parseInt(process.env.PORT ?? '3001', 10);
 
-type CharacterModel = 'bunny' | 'human';
+type CharacterModel = 'bunny' | 'human' | 'cartoon';
 type PlayerState = {
   userId: string;
   x: number;

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -101,6 +101,15 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
         }
       });
 
+      if (roomChat.length !== 0) {
+        ws.send(
+          JSON.stringify({
+            type: 'messageInit',
+            userId,
+            messages: roomChat,
+          })
+        );
+      }
       // 다른 플레이어에게 입장 알림
       broadcast(room, userId, raw);
       return;

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -170,7 +170,10 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
       myUserId,
       JSON.stringify({ type: 'leave', userId: myUserId })
     );
-    if (room.size === 0) rooms.delete(roomId);
+    if (room.size === 0) {
+      roomChats.delete(roomId);
+      rooms.delete(roomId);
+    }
   });
 
   ws.on('error', (err) => {

--- a/src/components/exhibition-gallery/GalleryEntryModal.tsx
+++ b/src/components/exhibition-gallery/GalleryEntryModal.tsx
@@ -14,6 +14,7 @@ const CONTROLS = [
 const MODELS: { value: CharacterModel; label: string; emoji: string }[] = [
   { value: 'human', label: '사람', emoji: '🧑' },
   { value: 'bunny', label: '토끼', emoji: '🐰' },
+  { value: 'cartoon', label: '카툰', emoji: '🎨' },
 ];
 
 interface GalleryEntryModalProps {

--- a/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
+++ b/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
@@ -54,7 +54,13 @@ function RemotePlayer({
         </Html>
       )}
 
-      {playerModel === 'human' ? <HumanCharacter /> : playerModel === 'bunny' ? <BunnyCharacter /> : <CartoonCharacter />}
+      {playerModel === 'human' ? (
+        <HumanCharacter />
+      ) : playerModel === 'bunny' ? (
+        <BunnyCharacter />
+      ) : (
+        <CartoonCharacter />
+      )}
     </group>
   );
 }

--- a/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
+++ b/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
@@ -4,7 +4,8 @@ import * as THREE from 'three';
 import { PlayerInfo, RemotePlayerData } from '@/hooks/usePlayerSocket';
 import { Html } from '@react-three/drei';
 import HumanCharacter from './characters/HumanCharacter';
-import BunnyCharacter from '@/components/exhibition-gallery/threejs/characters/BunnyCharacter';
+import BunnyCharacter from './characters/BunnyCharacter';
+import CartoonCharacter from './characters/CartoonCharacter';
 
 function RemotePlayer({
   playerInfo,
@@ -53,7 +54,7 @@ function RemotePlayer({
         </Html>
       )}
 
-      {playerModel === 'human' ? <HumanCharacter /> : <BunnyCharacter />}
+      {playerModel === 'human' ? <HumanCharacter /> : playerModel === 'bunny' ? <BunnyCharacter /> : <CartoonCharacter />}
     </group>
   );
 }

--- a/src/components/exhibition-gallery/threejs/characters/CartoonCharacter.tsx
+++ b/src/components/exhibition-gallery/threejs/characters/CartoonCharacter.tsx
@@ -1,0 +1,88 @@
+import React, { useRef, useMemo, useEffect } from 'react';
+import { useGraph, useFrame } from '@react-three/fiber';
+import { useGLTF, useAnimations } from '@react-three/drei';
+import { SkeletonUtils, GLTF } from 'three-stdlib';
+import * as THREE from 'three';
+
+const CARTOON_PATH = '/GLBformat/character/cartoon.glb';
+const Y_OFFSET = 0;
+const FADE_DURATION = 0.2;
+
+type ActionName = 'Running' | 'Walking';
+
+type CartoonGLTFResult = GLTF & {
+  nodes: { char1: THREE.SkinnedMesh; Hips: THREE.Bone };
+  materials: { Material_1: THREE.MeshStandardMaterial };
+  animations: THREE.AnimationClip[];
+};
+
+export default function CartoonCharacter() {
+  const groupRef = useRef<THREE.Group>(null);
+  const actionsRef = useRef<Partial<Record<ActionName, THREE.AnimationAction>>>({});
+  const currentActionRef = useRef<THREE.AnimationAction | null>(null);
+
+  const { scene, animations } = useGLTF(CARTOON_PATH);
+  const clone = useMemo(() => SkeletonUtils.clone(scene), [scene]);
+  const { nodes, materials } = useGraph(clone) as unknown as CartoonGLTFResult;
+  const { actions } = useAnimations(animations, groupRef);
+
+  const prevPos = useRef(new THREE.Vector3());
+  const tempPos = useRef(new THREE.Vector3());
+
+  useEffect(() => {
+    (['Walking', 'Running'] as ActionName[]).forEach((name) => {
+      const action = actions[name];
+      if (action) actionsRef.current[name] = action;
+    });
+
+    const walkAction = actionsRef.current['Walking'];
+    if (walkAction) {
+      walkAction.play();
+      walkAction.paused = true;
+      currentActionRef.current = walkAction;
+    }
+  }, [actions]);
+
+  useFrame(() => {
+    if (!groupRef.current) return;
+
+    groupRef.current.getWorldPosition(tempPos.current);
+    const posMoved = tempPos.current.distanceTo(prevPos.current) > 0.002;
+
+    const switchTo = (name: ActionName) => {
+      const next = actionsRef.current[name];
+      const current = currentActionRef.current;
+      if (!next) return;
+      if (next === current) {
+        next.paused = false;
+        return;
+      }
+      current?.fadeOut(FADE_DURATION);
+      next.reset().fadeIn(FADE_DURATION).play();
+      currentActionRef.current = next;
+    };
+
+    if (posMoved) {
+      switchTo('Walking');
+    } else {
+      if (currentActionRef.current) currentActionRef.current.paused = true;
+    }
+
+    prevPos.current.copy(tempPos.current);
+  });
+
+  return (
+    <group ref={groupRef} dispose={null}>
+      <group name="Armature" scale={0.01} position={[0, Y_OFFSET, 0]}>
+        <primitive object={nodes.Hips} />
+        <skinnedMesh
+          geometry={nodes.char1.geometry}
+          material={materials.Material_1}
+          skeleton={nodes.char1.skeleton}
+        />
+      </group>
+    </group>
+  );
+}
+
+useGLTF.preload(CARTOON_PATH);

--- a/src/components/exhibition-gallery/threejs/characters/CartoonCharacter.tsx
+++ b/src/components/exhibition-gallery/threejs/characters/CartoonCharacter.tsx
@@ -18,7 +18,9 @@ type CartoonGLTFResult = GLTF & {
 
 export default function CartoonCharacter() {
   const groupRef = useRef<THREE.Group>(null);
-  const actionsRef = useRef<Partial<Record<ActionName, THREE.AnimationAction>>>({});
+  const actionsRef = useRef<Partial<Record<ActionName, THREE.AnimationAction>>>(
+    {}
+  );
   const currentActionRef = useRef<THREE.AnimationAction | null>(null);
 
   const { scene, animations } = useGLTF(CARTOON_PATH);

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import * as THREE from 'three';
 
 export type SendMoveFn = (camera: THREE.Camera) => void;
-export type CharacterModel = 'bunny' | 'human';
+export type CharacterModel = 'bunny' | 'human' | 'cartoon';
 
 export type RemotePlayerData = {
   x: number;

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -18,7 +18,11 @@ export type PlayerInfo = {
 };
 
 export type ChatHistory = { userId: string; userName: string; message: string };
-
+type ChatRaw = {
+  userId: string;
+  timestamp: string;
+  message: string;
+};
 type OutboundMessage =
   | { type: 'join'; userId: string; userName: string; model: CharacterModel }
   | { type: 'leave'; userId: string }
@@ -44,7 +48,7 @@ type InboundMessage =
   | { type: 'join'; userId: string; userName: string; model: CharacterModel }
   | { type: 'leave'; userId: string }
   | { type: 'message'; userId: string; message: string }
-  | { type: 'messageInit'; userId: string; messages: string };
+  | { type: 'messageInit'; userId: string; messages: ChatRaw[] };
 const THROTTLE_MS = 50;
 const _forward = new THREE.Vector3();
 
@@ -84,6 +88,7 @@ export function usePlayerSocket(
 
     ws.onopen = () => {
       const myName = userName ?? userId;
+      userNamesRef.current.set(userId, myName);
       ws.send(
         JSON.stringify({ type: 'join', userId, userName: myName, model })
       );
@@ -92,7 +97,7 @@ export function usePlayerSocket(
     ws.onmessage = (e: MessageEvent) => {
       const msg: InboundMessage = JSON.parse(e.data);
 
-      if (msg.userId === userId) return;
+      // if (msg.userId === userId) return;
 
       if (msg.type === 'move') {
         remotePlayersRef.current.set(msg.userId, {
@@ -126,7 +131,13 @@ export function usePlayerSocket(
         userNamesRef.current.delete(msg.userId);
         setPlayerInfo((prev) => prev.filter((p) => p.userId !== msg.userId));
       } else if (msg.type === 'messageInit') {
-        console.log(msg)
+        const raw = msg.messages;
+        const parsed = raw.map((chat) => ({
+          userId: chat.userId,
+          userName: userNamesRef.current.get(chat.userId) ?? 'guest',
+          message: chat.message,
+        }));
+        setChatHistory(parsed);
       }
     };
 

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -43,8 +43,8 @@ type InboundMessage =
     }
   | { type: 'join'; userId: string; userName: string; model: CharacterModel }
   | { type: 'leave'; userId: string }
-  | { type: 'message'; userId: string; message: string };
-
+  | { type: 'message'; userId: string; message: string }
+  | { type: 'messageInit'; userId: string; messages: string };
 const THROTTLE_MS = 50;
 const _forward = new THREE.Vector3();
 
@@ -125,6 +125,8 @@ export function usePlayerSocket(
         remotePlayersRef.current.delete(msg.userId);
         userNamesRef.current.delete(msg.userId);
         setPlayerInfo((prev) => prev.filter((p) => p.userId !== msg.userId));
+      } else if (msg.type === 'messageInit') {
+        console.log(msg)
       }
     };
 


### PR DESCRIPTION
## 📌 개요

카툰 캐릭터를 추가하고, 신규 접속자에게 기존 채팅 내역을 전달하는 기능을 구현했습니다.

## 🔍 변경 사항

> 주요 변경 사항을 설명해주세요.

카툰 캐릭터 추가
- CartoonCharacter.tsx 컴포넌트 생성
- CharacterModel 타입에 'cartoon' 추가 (클라이언트/서버 동기화)
- 입장 모달 캐릭터 선택지에 카툰 추가
- RemotePlayers에서 cartoon 모델 분기 렌더링 추가

채팅 히스토리 보존 (server/ws.ts, usePlayerSocket.ts)
- 서버: 신규 접속자 join 시 roomChats에 저장된 기존 채팅 내역을 messageInit 타입으로 전송
- 클라이언트: messageInit 수신 핸들러 추가, 기존 채팅 히스토리를 chatHistory state에 반영

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #170 

## 📸 스크린샷 (UI 변경 시 필수)
<img width="757" height="585" alt="스크린샷 2026-06-11 오전 11 36 27" src="https://github.com/user-attachments/assets/28e07503-6db8-48a3-8408-af0e5ab464f2" />


## 🧪 테스트 결과

- [ ] 코드가 정상 작동하는 지 확인했나요?
- [ ] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [ ] 라우팅이 정상 작동하는 지 확인했나요?
- [ ] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항
허허 시열님 이번에도 몰래 찍었습니다요
