### PR TITLE
[PR] 전시회 상세 페이지 공유 버튼 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  // 같은 네트워크의 기기(폰 등)에서 로컬 IP로 dev 서버 접속 허용
+  // (와이파이 환경에 따라 본인 IP를 추가하세요: ipconfig getifaddr en0)
+  allowedDevOrigins: ['192.168.45.184'],
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.11.0",
         "next": "16.2.4",
+        "qrcode.react": "^4.2.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.74.0",
@@ -9126,6 +9127,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.11.0",
     "next": "16.2.4",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.74.0",

--- a/src/components/exhibition/ExhibitionActionBar.tsx
+++ b/src/components/exhibition/ExhibitionActionBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowRight, Calendar, Heart, Settings, Star } from 'lucide-react';
+import { Calendar, Heart, Settings, Star } from 'lucide-react';
 import Link from 'next/link';
 import type { ExhibitionDetailItem } from '@/lib/exhibition/server';
 import { formatDate } from '@/lib/exhibition/dateStatus';
@@ -8,6 +8,7 @@ import { Button } from '../ui/button';
 import { cn } from '@/lib/utils';
 import { toggleExhibitionLike } from '@/lib/exhibition/service';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
+import ShareDialog from './ShareDialog';
 
 interface ActionProps {
   exhibition: ExhibitionDetailItem;
@@ -77,14 +78,7 @@ export default function ExhibitionActionBar({
           <Heart className={cn('h-4 w-4', liked && 'fill-red-500')} />
           {liked ? '좋아요 취소' : '좋아요'}
         </Button>
-        <Link
-          href={`/gallery/${exhibition.id}`}
-          className="bg-primary inline-flex h-9 items-center gap-1.5 rounded-xl px-2.5 text-sm font-medium text-white transition-colors hover:bg-[#E09415]"
-        >
-          <span>🎨</span>
-          전시회 입장하기
-          <ArrowRight className="h-4 w-4" />
-        </Link>
+        <ShareDialog exhibitionId={exhibition.id} title={exhibition.title} />
       </div>
     </section>
   );

--- a/src/components/exhibition/ShareDialog.tsx
+++ b/src/components/exhibition/ShareDialog.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Check, Copy, Share2 } from 'lucide-react';
+import { DialogTrigger } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import AppDialog from '@/components/shared/AppDialog';
+
+interface ShareDialogProps {
+  exhibitionId: string;
+  title: string;
+}
+
+export default function ShareDialog({ exhibitionId, title }: ShareDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [shareUrl, setShareUrl] = useState('');
+
+  // window는 클라이언트에서만 접근 가능하므로 열리는 시점에 URL 생성
+  const handleOpenChange = (v: boolean) => {
+    if (v) setShareUrl(`${window.location.origin}/exhibitions/${exhibitionId}`);
+    setOpen(v);
+  };
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(shareUrl);
+      } else {
+        // Clipboard API는 보안 컨텍스트(HTTPS/localhost) 전용이라
+        // HTTP(로컬 IP 접속 등) 환경에서는 구식 방식으로 복사
+        const textarea = document.createElement('textarea');
+        textarea.value = shareUrl;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        textarea.remove();
+      }
+      setCopied(true);
+    } catch (e) {
+      console.error('clipboard copy fail', e);
+    }
+  };
+
+  const trigger = (
+    <DialogTrigger
+      render={
+        <Button
+          size="lg"
+          className="text-secondary/60 hover:bg-primary/20 rounded-xl bg-[#FAF7F2] transition-colors"
+        />
+      }
+    >
+      <Share2 className="h-4 w-4" />
+      공유
+    </DialogTrigger>
+  );
+
+  return (
+    <AppDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      trigger={trigger}
+      title="전시회 공유하기"
+      className="max-w-sm"
+    >
+      <div className="flex flex-col items-center gap-5 py-2">
+        <p className="text-secondary/60 text-center text-sm">
+          QR코드를 스캔하거나 링크를 복사해
+          <br />
+          <span className="text-secondary font-semibold">{title}</span> 전시회를
+          공유해보세요!
+        </p>
+
+        {/* QR코드 */}
+        <div className="rounded-2xl border border-gray-100 bg-white p-4 shadow-[0_1px_4px_rgba(44,40,38,0.06)]">
+          {shareUrl && <QRCodeSVG value={shareUrl} size={160} marginSize={1} />}
+        </div>
+
+        {/* 링크 복사 */}
+        <div className="flex w-full items-center gap-2">
+          <input
+            type="text"
+            value={shareUrl}
+            readOnly
+            className="text-secondary/70 bg-surface w-full truncate rounded-xl border border-gray-200 px-4 py-2.5 text-sm outline-none"
+          />
+          <Button
+            onClick={handleCopy}
+            className="shrink-0 rounded-xl px-4 py-2.5"
+          >
+            {copied ? (
+              <>
+                <Check className="h-4 w-4" />
+                복사됨
+              </>
+            ) : (
+              <>
+                <Copy className="h-4 w-4" />
+                복사
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </AppDialog>
+  );
+}


### PR DESCRIPTION
## 📌 개요

전시회 상세 페이지에 "전시회 입장하기" 버튼이 상단 액션 바와 하단 배너에 중복으로 2개 존재했습니다. 
그래서 상단 버튼을 제거하고 그 자리에 공유 기능(QR 코드 + 링크 복사)을 추가하여 선생님 → 학부모/학생 공유 동선을 마련했습니다.

## 🔍 변경 사항

- `ShareDialog` 컴포넌트 추가 (AppDialog 재사용)
  - QR코드 표시: `qrcode.react` (SVG 렌더, 경량)
  - 링크 복사: Clipboard API + 복사 완료 피드백 (2초)
  - HTTP 등 Clipboard API 미지원 환경용 `execCommand` fallback 포함
- `ExhibitionActionBar`: 입장하기 버튼 제거을 공유 버튼으로 교체함.
- `next.config.ts`: `allowedDevOrigins` 추가 - 같은 네트워크(동일한 와이파이 연결하면 됩니다~) 기기(폰)에서 로컬 IP로 dev 서버 접속해 QR 테스트 가능 (dev 전용, 배포 무관)

## 🔗 관련 이슈 번호

close #174 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1512" height="760" alt="스크린샷 2026-06-12 오후 4 44 18" src="https://github.com/user-attachments/assets/b9806040-bc39-444d-a804-f3e584f621f0" />

<img width="1512" height="760" alt="스크린샷 2026-06-12 오후 4 44 27" src="https://github.com/user-attachments/assets/644b5489-52a8-432f-beb0-5ea658edc25e" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- 공유 URL은 `window.location.origin` 기반이라 배포 환경에서 자동으로 실제 도메인이 적용됩니다.
- 폰 기기 테스트 완료: 같은 와이파이에서 로컬 IP 접속 ->  QR 스캔 -> 전시회 페이지 정상 진입 확인했습니다!

**next.config.ts에 allowedDevOrigins 설정 추가했습니다.**

공유하기 기능을 폰으로 테스트하려면 dev 서버에 로컬 IP (예: http://192.168.x.x:3000) 으로 접속해야 하는데, Next.js 16부터 localhost 외 origin 접속이 기본 차단되어 허용 설정을 넣었습니다.

allowedDevOrigins: ['192.168.*']

- dev 서버 전용 옵션이라 빌드/배포에는 아예 적용되지 않습니다.
- 기존 localhost 개발 방식도 그대로 동작합니다.

**폰으로 테스트하는 방법**

1. PC와 폰을 같은 와이파이에 연결
2. 터미널에서 ipconfig getifaddr en0으로 PC IP 확인
3. 폰 브라우저에서 http://<PC IP>:3000 접속

🚧 주의: IP 접속에서는 로그인이 안 됩니다!
Supabase 인증 리다이렉트 URL이 localhost 기준으로 등록돼 있어서인데, IP는 와이파이마다 바뀌어서 등록 관리할 실익이 없어 그대로 둡니다. 로그인 필요한 기능은 PC(localhost)에서, 폰에서는 비로그인 동선 (전시회 관람, QR 스캔 확인 등)만 테스트하면 될 거 같습니다~