### PR TITLE
[PR] 전시관 내 동영상 변환 작품 표시

### DIFF
--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef } from 'react';
 import {
+  CanvasTexture,
   Group,
   Mesh,
   MeshStandardMaterial,
+  RepeatWrapping,
   SRGBColorSpace,
   Texture,
   Vector3,
@@ -10,7 +12,7 @@ import {
 } from 'three';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
-import { Download, Heart } from 'lucide-react';
+import { Download, Heart, Play } from 'lucide-react';
 import { checkImgSize } from '@/lib/gallery/image';
 import { GalleryUIArtworkProps } from '@/types/gallery';
 
@@ -21,6 +23,26 @@ const MAT_D = 0.035;
 const VIDEO_NEAR_THRESHOLD = 5;
 
 type VideoData = { video: HTMLVideoElement; texture: VideoTexture };
+
+// 골드 프레임 위를 흐르는 빛 띠(그라데이션) emissive 텍스처
+function createGoldSweepTexture() {
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 1;
+  const ctx = canvas.getContext('2d')!;
+  const grad = ctx.createLinearGradient(0, 0, 256, 0);
+  grad.addColorStop(0, '#221500');
+  grad.addColorStop(0.35, '#553a00');
+  grad.addColorStop(0.5, '#ffe9a8'); // 하이라이트 띠
+  grad.addColorStop(0.65, '#553a00');
+  grad.addColorStop(1, '#221500');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, 256, 1);
+  const tex = new CanvasTexture(canvas);
+  tex.wrapS = RepeatWrapping;
+  tex.wrapT = RepeatWrapping;
+  return tex;
+}
 
 export default function Painting({
   img,
@@ -41,10 +63,29 @@ export default function Painting({
 }) {
   const localRef = useRef<Group>(null);
   const meshRef = useRef<Mesh>(null);
+  const frameMatRef = useRef<MeshStandardMaterial>(null);
   const worldPosRef = useRef(new Vector3());
   const isNearRef = useRef(false);
   const mountedAtRef = useRef(0);
   const videoDataRef = useRef<VideoData | null>(null);
+  const sweepTextureRef = useRef<CanvasTexture | null>(null);
+
+  // 영상 작품 전용 골드 sweep 텍스처 생성 후 프레임 emissiveMap에 연결
+  useEffect(() => {
+    if (!videoUrl) return;
+    const tex = createGoldSweepTexture();
+    sweepTextureRef.current = tex;
+    const mat = frameMatRef.current;
+    if (mat) {
+      mat.emissiveMap = tex;
+      mat.needsUpdate = true;
+    }
+    return () => {
+      sweepTextureRef.current = null;
+      if (mat) mat.emissiveMap = null;
+      tex.dispose();
+    };
+  }, [videoUrl]);
 
   useEffect(() => {
     mountedAtRef.current = Date.now();
@@ -68,7 +109,17 @@ export default function Painting({
     };
   }, [videoUrl]);
 
-  useFrame(({ camera }) => {
+  useFrame(({ camera, clock }) => {
+    // 영상 작품 프레임: 빛 띠(그라데이션)가 프레임을 따라 흐르고
+    // 전체 밝기도 은은하게 맥동
+    if (videoUrl && frameMatRef.current) {
+      const t = clock.elapsedTime;
+      if (sweepTextureRef.current) {
+        sweepTextureRef.current.offset.x = -t * 0.3;
+      }
+      frameMatRef.current.emissiveIntensity = 1.1 + Math.sin(t * 2.2) * 0.25;
+    }
+
     const videoData = videoDataRef.current;
     if (!localRef.current || !meshRef.current) return;
     localRef.current.getWorldPosition(worldPosRef.current);
@@ -114,14 +165,31 @@ export default function Painting({
       }}
       position={[0, 0, 0.3]}
     >
-      {/* 외부 프레임 */}
+      {/* 외부 프레임 — 영상 변환 작품은 두꺼운 황금 메탈 프레임으로 멀리서도 구분 */}
       <mesh>
-        <boxGeometry args={[imgW + FRAME_M * 2, imgH + FRAME_M * 2, FRAME_D]} />
-        <meshStandardMaterial
-          color="#2C2926"
-          roughness={0.3}
-          metalness={0.08}
+        <boxGeometry
+          args={[
+            imgW + (videoUrl ? FRAME_M * 2.6 : FRAME_M * 2),
+            imgH + (videoUrl ? FRAME_M * 2.6 : FRAME_M * 2),
+            FRAME_D,
+          ]}
         />
+        {videoUrl ? (
+          <meshStandardMaterial
+            ref={frameMatRef}
+            color="#FFD24A"
+            emissive="#FFAA00"
+            emissiveIntensity={0.9}
+            roughness={0.18}
+            metalness={0.85}
+          />
+        ) : (
+          <meshStandardMaterial
+            color="#2C2926"
+            roughness={0.3}
+            metalness={0.08}
+          />
+        )}
       </mesh>
 
       {/* 매트 보드 */}
@@ -135,6 +203,22 @@ export default function Painting({
         <planeGeometry args={[imgW, imgH]} />
         <meshStandardMaterial map={img} />
       </mesh>
+
+      {/* 영상 변환 작품 ▶ 배지 — 액자 우하단 모서리 */}
+      {videoUrl && (
+        <Html
+          transform
+          position={[imgW / 2 + FRAME_M, -imgH / 2 - FRAME_M, 0.12]}
+          distanceFactor={2}
+          center
+          zIndexRange={[30, 0]}
+          style={{ pointerEvents: 'none' }}
+        >
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-black/45 backdrop-blur-sm">
+            <Play size={13} className="ml-0.5 fill-white text-white" />
+          </div>
+        </Html>
+      )}
 
       {/* 작품 정보 */}
       <Html


### PR DESCRIPTION
## 📌 개요

동영상 변환 작품이 전시관 내에서 일반 작품과 똑같이 보여서, 가까이 다가가 영상이 재생되는 걸 직접 확인해야만 변환 작품인지 알 수 있었습니다. 영상 작품을 멀리서도 한눈에 구분할 수 있도록 시각적인 표시를 추가했습니다.

## 🔍 변경 사항

- 골드 메탈 프레임: 영상 작품(`video_url` 보유한 작품)의 액자 프레임을 금속 재질의 골드로 변경했고, 그라데이션 텍스처를 emissiveMap에 연결하고 offset을 흘려 빛 하이라이트가 프레임을 따라 흐르는 효과를 적용했습니다.
 
- 재생 배지: 액자 우하단에 반투명 블랙 배지 (모달보다 아래 z-index, 클릭 방해 없음)

## 🔗 관련 이슈 번호

close #176 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1512" height="760" alt="스크린샷 2026-06-13 오전 12 13 55" src="https://github.com/user-attachments/assets/7848c67f-8df5-4b0f-99f1-17af3221c4ca" />

<img width="1512" height="760" alt="스크린샷 2026-06-13 오전 12 14 42" src="https://github.com/user-attachments/assets/34410d1e-2795-4fdc-8fb6-2a6cb26f8d5d" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항
