### PR TITLE
[PR] 다건 등록 업로드 취소(AbortController) 추가

### DIFF
--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -87,6 +87,7 @@ export default function BulkWorkDialog() {
     fail: number;
   } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const {
     register,
@@ -115,22 +116,34 @@ export default function BulkWorkDialog() {
   const handleRemove = (index: number) => remove(index);
 
   const handleClose = useCallback(() => {
+    // 진행 중인 업로드가 있으면 모두 취소
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setUploading(false);
     reset();
     setResult(null);
   }, [reset]);
 
   const submitHandler = useCallback(
     async (data: BulkForm) => {
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
       setUploading(true);
+
       const results = await Promise.allSettled(
         data.rows.map((row) => {
           const formData = new FormData();
           formData.append('image_url', row.image);
           formData.append('title', row.title);
           formData.append('artist_name', row.artist_name);
-          return postArtWorksByExhibitionId(id, formData);
+          return postArtWorksByExhibitionId(id, formData, controller.signal);
         })
       );
+
+      // 업로드 도중 다이얼로그를 닫아 취소된 경우, 후속 처리를 건너뛴다
+      if (controller.signal.aborted) return;
+
+      abortControllerRef.current = null;
       setUploading(false);
 
       const success = results.filter((r) => r.status === 'fulfilled').length;

--- a/src/components/exhibition/manage/BulkWorkDialog.tsx
+++ b/src/components/exhibition/manage/BulkWorkDialog.tsx
@@ -126,6 +126,8 @@ export default function BulkWorkDialog() {
 
   const submitHandler = useCallback(
     async (data: BulkForm) => {
+      // 업로드가 이미 진행 중이면 재진입 차단 (이전 배치 취소 핸들 보호)
+      if (abortControllerRef.current) return;
       const controller = new AbortController();
       abortControllerRef.current = controller;
       setUploading(true);

--- a/src/lib/artwork/service.ts
+++ b/src/lib/artwork/service.ts
@@ -1,10 +1,12 @@
 export async function postArtWorksByExhibitionId(
   id: string,
-  formData: FormData
+  formData: FormData,
+  signal?: AbortSignal
 ) {
   const res = await fetch(`/api/exhibitions/${id}/artworks`, {
     method: 'POST',
     body: formData,
+    signal,
   });
   if (!res.ok) {
     const error = await res.json();


### PR DESCRIPTION
## 📌 개요

작품 다건 등록 시 업로드가 진행되는 도중 다이얼로그를 닫아도 업로드 요청이 백그라운드에서 계속 실행되던 문제를 수정했습니다!
닫은 뒤에는 화면 갱신이 호출되지 않아 사용자가 등록 여부를 알 수 없었고, 등록이 안 된 줄 알고 재시도하면 중복 등록이 발생할 수 있었습니다.

## 🔍 변경 사항

- `postArtWorksByExhibitionId`에 `AbortSignal` 파라미터 추가
- BulkWorkDialog: 업로드 시작 시 AbortController 생성, 각 요청에 signal 연결
- 다이얼로그 닫을 때(handleClose) 진행 중인 업로드 일괄 취소 + uploading 상태 리셋
- 취소 시에 후속 처리(상태 갱신 + 재시도 폼 구성)를 건너뛰어 사용자 취소를 실패로 집계하지 않음

## 🔗 관련 이슈 번호

close #178 

## 📸 스크린샷 (UI 변경 시 필수)

UI 변화 없습니다.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- 업로드 도중 취소하면 서버 콘솔에 `Error: aborted (ECONNRESET)` 로그가 남습니다. 이 현상은 클라이언트가 연결을 끊을 때 Next.js가 기록하는 정상 현상이고, 라우트 핸들러 진입 전 연결 레벨에서 발생해 앱에서 잡을 수 없습니다. (취소가 실제로 동작했다는 증거입니다~)

- abort는 아직 전송 중인 요청만 끊습니다. 이미 서버에 도착해 처리 중인 요청은 완료되므로 일부 작품은 등록될 수 있습니다. 다수의 전송 중 요청을 취소함으로써 중복 위험을 크게 줄이는 것이 목적입니다.
