### PR TITLE
[PR] 이모지 반응 추가

### DIFF
--- a/src/app/(exhibitions)/exhibitions/[id]/page.tsx
+++ b/src/app/(exhibitions)/exhibitions/[id]/page.tsx
@@ -124,6 +124,8 @@ export default async function ExhibitionDetail({
                     likes: work.likes,
                     liked: work.liked,
                     videoUrl: work.videoUrl,
+                    reactions: work.reactions,
+                    myReaction: work.myReaction,
                   }}
                   exhibitionId={exhibition.id}
                   exhibitionTitle={exhibition.title}

--- a/src/app/(mypage)/artworks/page.tsx
+++ b/src/app/(mypage)/artworks/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getAuthContext } from '@/lib/auth/getAuthContext';
 import { createClient } from '@/lib/supabase/server';
+import { fetchArtworkReactions } from '@/lib/artwork/reactions';
 import type { Artwork } from '@/types/artwork';
 import ArtworksScreen from '@/components/my-artworks/ArtworksScreen';
 
@@ -48,21 +49,28 @@ export default async function MyArtworksPage() {
 
   const likedSet = new Set((likedData ?? []).map((l) => l.artwork_id));
 
-  const artworks: Artwork[] = ((data ?? []) as unknown as RawArtwork[]).map(
-    (raw) => ({
-      id: raw.id,
-      exhibitionId: raw.exhibitions?.id ?? '',
-      title: raw.title,
-      artist: raw.artist_name ?? '',
-      description: raw.description ?? '',
-      exhibitionTitle: raw.exhibitions?.title ?? '',
-      academyName: raw.exhibitions?.profiles?.institution ?? '',
-      imageUrl: raw.image_url ?? '',
-      likesCount: (raw.artwork_likes ?? [])[0]?.count ?? 0,
-      isLiked: likedSet.has(raw.id),
-      createdAt: raw.created_at,
-    })
+  const rawArtworks = (data ?? []) as unknown as RawArtwork[];
+  const { reactionsMap, myReactionMap } = await fetchArtworkReactions(
+    supabase,
+    rawArtworks.map((raw) => raw.id),
+    user.id
   );
+
+  const artworks: Artwork[] = rawArtworks.map((raw) => ({
+    id: raw.id,
+    exhibitionId: raw.exhibitions?.id ?? '',
+    title: raw.title,
+    artist: raw.artist_name ?? '',
+    description: raw.description ?? '',
+    exhibitionTitle: raw.exhibitions?.title ?? '',
+    academyName: raw.exhibitions?.profiles?.institution ?? '',
+    imageUrl: raw.image_url ?? '',
+    likesCount: (raw.artwork_likes ?? [])[0]?.count ?? 0,
+    isLiked: likedSet.has(raw.id),
+    createdAt: raw.created_at,
+    reactions: reactionsMap.get(raw.id) ?? {},
+    myReaction: myReactionMap.get(raw.id) ?? null,
+  }));
 
   return <ArtworksScreen artworks={artworks} />;
 }

--- a/src/app/(mypage)/wish-list/page.tsx
+++ b/src/app/(mypage)/wish-list/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getAuthContext } from '@/lib/auth/getAuthContext';
 import { createClient } from '@/lib/supabase/server';
+import { fetchArtworkReactions } from '@/lib/artwork/reactions';
 import type { Artwork } from '@/types/artwork';
 import WishlistScreen from '@/components/my-wishlist/WishlistScreen';
 
@@ -42,29 +43,35 @@ export default async function WishlistPage() {
 
   if (error) throw new Error(error.message);
 
-  const artworks: Artwork[] = ((data ?? []) as unknown as LikeRow[])
-    .filter(
-      (
-        like
-      ): like is LikeRow & { artworks: NonNullable<LikeRow['artworks']> } =>
-        like.artworks !== null
-    )
-    .map((like) => {
-      const aw = like.artworks;
-      return {
-        id: aw.id,
-        exhibitionId: aw.exhibitions?.id ?? '',
-        title: aw.title,
-        artist: aw.artist_name ?? '',
-        description: aw.description ?? '',
-        exhibitionTitle: aw.exhibitions?.title ?? '',
-        academyName: aw.exhibitions?.profiles?.institution ?? '',
-        imageUrl: aw.image_url ?? '',
-        likesCount: aw.artwork_likes[0]?.count ?? 0,
-        isLiked: true,
-        createdAt: aw.created_at,
-      };
-    });
+  const validRows = ((data ?? []) as unknown as LikeRow[]).filter(
+    (like): like is LikeRow & { artworks: NonNullable<LikeRow['artworks']> } =>
+      like.artworks !== null
+  );
+
+  const { reactionsMap, myReactionMap } = await fetchArtworkReactions(
+    supabase,
+    validRows.map((like) => like.artworks.id),
+    user.id
+  );
+
+  const artworks: Artwork[] = validRows.map((like) => {
+    const aw = like.artworks;
+    return {
+      id: aw.id,
+      exhibitionId: aw.exhibitions?.id ?? '',
+      title: aw.title,
+      artist: aw.artist_name ?? '',
+      description: aw.description ?? '',
+      exhibitionTitle: aw.exhibitions?.title ?? '',
+      academyName: aw.exhibitions?.profiles?.institution ?? '',
+      imageUrl: aw.image_url ?? '',
+      likesCount: aw.artwork_likes[0]?.count ?? 0,
+      isLiked: true,
+      createdAt: aw.created_at,
+      reactions: reactionsMap.get(aw.id) ?? {},
+      myReaction: myReactionMap.get(aw.id) ?? null,
+    };
+  });
 
   return <WishlistScreen artworks={artworks} />;
 }

--- a/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/reactions/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/reactions/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+// 작품 이모지 반응 토글
+// - 반응 없음 → 추가 / 같은 이모지 → 해제 / 다른 이모지 → 교체
+const ALLOWED_EMOJIS = ['❤️', '😍', '😮', '👏'];
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ exhibitionId: string; artworksId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+    const { exhibitionId, artworksId } = await params;
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ message: 'no session' }, { status: 401 });
+    }
+
+    const { emoji } = await req.json();
+    if (typeof emoji !== 'string' || !ALLOWED_EMOJIS.includes(emoji)) {
+      return NextResponse.json({ message: 'invalid emoji' }, { status: 400 });
+    }
+
+    // 작품이 실제로 해당 전시회 소속인지 검증
+    const { data: artwork, error: artworkError } = await supabase
+      .from('artworks')
+      .select('id')
+      .eq('id', artworksId)
+      .eq('exhibition_id', exhibitionId)
+      .maybeSingle();
+
+    if (artworkError) {
+      console.log(artworkError);
+      return NextResponse.json(
+        { message: 'artwork lookup error' },
+        { status: 500 }
+      );
+    }
+    if (!artwork) {
+      return NextResponse.json(
+        { message: 'artwork not found in exhibition' },
+        { status: 404 }
+      );
+    }
+
+    // 기존 반응 조회
+    const { data: existing, error: exError } = await supabase
+      .from('artwork_reactions')
+      .select('id, emoji')
+      .eq('user_id', user.id)
+      .eq('artwork_id', artworksId)
+      .maybeSingle();
+
+    if (exError) {
+      console.log(exError);
+      return NextResponse.json(
+        { message: 'reaction search error' },
+        { status: 500 }
+      );
+    }
+
+    // 같은 이모지를 다시 누르면 해제
+    if (existing && existing.emoji === emoji) {
+      const { error } = await supabase
+        .from('artwork_reactions')
+        .delete()
+        .eq('id', existing.id);
+      if (error) {
+        console.log(error);
+        return NextResponse.json(
+          { message: 'failed to remove reaction' },
+          { status: 500 }
+        );
+      }
+      return NextResponse.json({ emoji: null });
+    }
+
+    // 다른 이모지면 교체, 없으면 추가 (upsert)
+    const { error } = await supabase.from('artwork_reactions').upsert(
+      {
+        artwork_id: artworksId,
+        user_id: user.id,
+        emoji,
+      },
+      { onConflict: 'user_id,artwork_id' }
+    );
+
+    if (error) {
+      console.log(error);
+      return NextResponse.json(
+        { message: 'failed to save reaction' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ emoji });
+  } catch (err) {
+    console.log(err);
+    return NextResponse.json({ message: 'server error' }, { status: 500 });
+  }
+}

--- a/src/components/exhibition/WorkDialog.tsx
+++ b/src/components/exhibition/WorkDialog.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useState } from 'react';
-import { likesToggle } from '@/lib/artwork/service';
+import { likesToggle, toggleReaction } from '@/lib/artwork/service';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import { useImageDownload } from '@/hooks/useImageDownload';
 import ArtworkDetailContent from '@/components/ui/ArtworkDetailContent';
@@ -16,6 +16,8 @@ export interface Work {
   likes: number;
   liked: boolean;
   videoUrl?: string | null;
+  reactions?: Record<string, number>;
+  myReaction?: string | null;
 }
 
 interface WorkDialogProps {
@@ -48,6 +50,42 @@ export default function WorkDialog({
     onToggle: () => likesToggle(exhibitionId, work.id),
     refreshOnSuccess: true,
   });
+
+  // 이모지 반응 (좋아요와 별개) — 낙관적 업데이트
+  const [reactions, setReactions] = useState<Record<string, number>>(
+    work.reactions ?? {}
+  );
+  const [myReaction, setMyReaction] = useState<string | null>(
+    work.myReaction ?? null
+  );
+
+  const handleReaction = async (emoji: string) => {
+    if (!isLoggedIn) return;
+
+    const prevReactions = reactions;
+    const prevMine = myReaction;
+
+    // 낙관적 계산: 같은 이모지 → 해제, 다른 이모지 → 교체
+    const next = { ...reactions };
+    if (prevMine) next[prevMine] = Math.max((next[prevMine] ?? 1) - 1, 0);
+    let nextMine: string | null;
+    if (prevMine === emoji) {
+      nextMine = null;
+    } else {
+      next[emoji] = (next[emoji] ?? 0) + 1;
+      nextMine = emoji;
+    }
+    setReactions(next);
+    setMyReaction(nextMine);
+
+    try {
+      await toggleReaction(exhibitionId, work.id, emoji);
+    } catch (err) {
+      console.error('reaction toggle error', err);
+      setReactions(prevReactions);
+      setMyReaction(prevMine);
+    }
+  };
 
   const { download } = useImageDownload();
 
@@ -133,6 +171,9 @@ export default function WorkDialog({
           isOwner={isOwner}
           isAnimating={isAnimating}
           onAnimate={handleAnimate}
+          reactions={reactions}
+          myReaction={myReaction}
+          onReact={handleReaction}
         />
       )}
     </>

--- a/src/components/exhibition/WorkDialog.tsx
+++ b/src/components/exhibition/WorkDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { likesToggle, toggleReaction } from '@/lib/artwork/service';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import { useImageDownload } from '@/hooks/useImageDownload';
@@ -58,9 +58,11 @@ export default function WorkDialog({
   const [myReaction, setMyReaction] = useState<string | null>(
     work.myReaction ?? null
   );
+  // 반응 요청 직렬화 — 응답 순서 역전으로 인한 UI/DB 불일치 방지
+  const reactionPendingRef = useRef(false);
 
   const handleReaction = async (emoji: string) => {
-    if (!isLoggedIn) return;
+    if (!isLoggedIn || reactionPendingRef.current) return;
 
     const prevReactions = reactions;
     const prevMine = myReaction;
@@ -78,12 +80,15 @@ export default function WorkDialog({
     setReactions(next);
     setMyReaction(nextMine);
 
+    reactionPendingRef.current = true;
     try {
       await toggleReaction(exhibitionId, work.id, emoji);
     } catch (err) {
       console.error('reaction toggle error', err);
       setReactions(prevReactions);
       setMyReaction(prevMine);
+    } finally {
+      reactionPendingRef.current = false;
     }
   };
 

--- a/src/components/my-artworks/ArtworkModal.tsx
+++ b/src/components/my-artworks/ArtworkModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { likesToggle, toggleReaction } from '@/lib/artwork/service';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import { useImageDownload } from '@/hooks/useImageDownload';
@@ -39,9 +39,11 @@ export default function ArtworkModal({
   const [myReaction, setMyReaction] = useState<string | null>(
     artwork.myReaction ?? null
   );
+  // 반응 요청 직렬화 — 응답 순서 역전으로 인한 UI/DB 불일치 방지
+  const reactionPendingRef = useRef(false);
 
   const handleReaction = async (emoji: string) => {
-    if (!isLoggedIn) return;
+    if (!isLoggedIn || reactionPendingRef.current) return;
 
     const prevReactions = reactions;
     const prevMine = myReaction;
@@ -58,12 +60,15 @@ export default function ArtworkModal({
     setReactions(next);
     setMyReaction(nextMine);
 
+    reactionPendingRef.current = true;
     try {
       await toggleReaction(artwork.exhibitionId, artwork.id, emoji);
     } catch (err) {
       console.error('reaction toggle error', err);
       setReactions(prevReactions);
       setMyReaction(prevMine);
+    } finally {
+      reactionPendingRef.current = false;
     }
   };
 

--- a/src/components/my-artworks/ArtworkModal.tsx
+++ b/src/components/my-artworks/ArtworkModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { likesToggle } from '@/lib/artwork/service';
+import { useState } from 'react';
+import { likesToggle, toggleReaction } from '@/lib/artwork/service';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import { useImageDownload } from '@/hooks/useImageDownload';
 import { Artwork } from '@/types/artwork';
@@ -31,6 +32,41 @@ export default function ArtworkModal({
     onSuccess: (nextLiked, nextLikes) => onLikeChange?.(nextLiked, nextLikes),
   });
 
+  // 이모지 반응 (좋아요와 별개) — 낙관적 업데이트
+  const [reactions, setReactions] = useState<Record<string, number>>(
+    artwork.reactions ?? {}
+  );
+  const [myReaction, setMyReaction] = useState<string | null>(
+    artwork.myReaction ?? null
+  );
+
+  const handleReaction = async (emoji: string) => {
+    if (!isLoggedIn) return;
+
+    const prevReactions = reactions;
+    const prevMine = myReaction;
+
+    const next = { ...reactions };
+    if (prevMine) next[prevMine] = Math.max((next[prevMine] ?? 1) - 1, 0);
+    let nextMine: string | null;
+    if (prevMine === emoji) {
+      nextMine = null;
+    } else {
+      next[emoji] = (next[emoji] ?? 0) + 1;
+      nextMine = emoji;
+    }
+    setReactions(next);
+    setMyReaction(nextMine);
+
+    try {
+      await toggleReaction(artwork.exhibitionId, artwork.id, emoji);
+    } catch (err) {
+      console.error('reaction toggle error', err);
+      setReactions(prevReactions);
+      setMyReaction(prevMine);
+    }
+  };
+
   const { download } = useImageDownload();
 
   const handleDownload = async () => {
@@ -56,6 +92,9 @@ export default function ArtworkModal({
       onClose={onClose}
       onLike={handleLike}
       onDownload={handleDownload}
+      reactions={reactions}
+      myReaction={myReaction}
+      onReact={handleReaction}
     />
   );
 }

--- a/src/components/my-artworks/ArtworksScreen.tsx
+++ b/src/components/my-artworks/ArtworksScreen.tsx
@@ -61,6 +61,7 @@ export default function ArtworksScreen({
         <ArtworkModal
           key={selectedArtwork.id}
           artwork={selectedArtwork}
+          isLoggedIn
           onClose={() => setSelectedArtwork(null)}
           onLikeChange={(liked, newCount) => {
             setArtworks((prev) =>

--- a/src/components/my-wishlist/WishlistScreen.tsx
+++ b/src/components/my-wishlist/WishlistScreen.tsx
@@ -60,6 +60,7 @@ export default function WishlistScreen({
         <ArtworkModal
           key={selectedArtwork.id}
           artwork={selectedArtwork}
+          isLoggedIn
           onClose={() => setSelectedArtwork(null)}
           onLikeChange={(liked) => {
             if (!liked) {

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -23,6 +23,9 @@ export interface ArtworkDetailContentProps {
   isOwner?: boolean;
   isAnimating?: boolean;
   onAnimate?: () => void;
+  reactions?: Record<string, number>;
+  myReaction?: string | null;
+  onReact?: (emoji: string) => void;
 }
 
 export default function ArtworkDetailContent({
@@ -43,9 +46,22 @@ export default function ArtworkDetailContent({
   isOwner = false,
   isAnimating = false,
   onAnimate,
+  reactions = {},
+  myReaction = null,
+  onReact,
 }: ArtworkDetailContentProps) {
   const [showLoginHint, setShowLoginHint] = useState(false);
   const [showVideo, setShowVideo] = useState(false);
+
+  const REACTIONS = ['❤️', '😍', '😮', '👏'];
+
+  const handleReactClick = (emoji: string) => {
+    if (isLoggedIn === false) {
+      setShowLoginHint(true);
+      return;
+    }
+    onReact?.(emoji);
+  };
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -196,6 +212,38 @@ export default function ArtworkDetailContent({
               {description}
             </p>
           )}
+
+          {/* 이모지 반응 */}
+          <div className="mb-4 flex flex-wrap gap-2">
+            {REACTIONS.map((emoji) => {
+              const count = reactions[emoji] ?? 0;
+              const active = myReaction === emoji;
+              return (
+                <button
+                  key={emoji}
+                  onClick={() => handleReactClick(emoji)}
+                  className={cn(
+                    'flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[13px] transition-colors',
+                    active
+                      ? 'border-[#F4845F] bg-[#FDEEE8]'
+                      : 'border-[#EDEBE4] hover:bg-[#F5F0E8]'
+                  )}
+                >
+                  <span className="text-[15px]">{emoji}</span>
+                  {count > 0 && (
+                    <span
+                      className={cn(
+                        'font-medium',
+                        active ? 'text-[#D9663F]' : 'text-[#888780]'
+                      )}
+                    >
+                      {count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
 
           <div className="flex items-center gap-1.5">
             <span className="h-1.5 w-1.5 rounded-full bg-[#F4845F]" />

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -53,7 +53,12 @@ export default function ArtworkDetailContent({
   const [showLoginHint, setShowLoginHint] = useState(false);
   const [showVideo, setShowVideo] = useState(false);
 
-  const REACTIONS = ['❤️', '😍', '😮', '👏'];
+  const REACTIONS: { emoji: string; label: string }[] = [
+    { emoji: '❤️', label: '좋아요' },
+    { emoji: '😍', label: '멋져요' },
+    { emoji: '😮', label: '놀라워요' },
+    { emoji: '👏', label: '대단해요' },
+  ];
 
   const handleReactClick = (emoji: string) => {
     if (isLoggedIn === false) {
@@ -215,7 +220,7 @@ export default function ArtworkDetailContent({
 
           {/* 이모지 반응 */}
           <div className="mb-4 flex flex-wrap gap-2">
-            {REACTIONS.map((emoji) => {
+            {REACTIONS.map(({ emoji, label }) => {
               const count = reactions[emoji] ?? 0;
               const active = myReaction === emoji;
               return (
@@ -230,6 +235,14 @@ export default function ArtworkDetailContent({
                   )}
                 >
                   <span className="text-[15px]">{emoji}</span>
+                  <span
+                    className={cn(
+                      'font-medium',
+                      active ? 'text-[#D9663F]' : 'text-[#444340]'
+                    )}
+                  >
+                    {label}
+                  </span>
                   {count > 0 && (
                     <span
                       className={cn(

--- a/src/lib/artwork/reactions.ts
+++ b/src/lib/artwork/reactions.ts
@@ -1,0 +1,41 @@
+import { createClient } from '@/lib/supabase/server';
+
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
+
+export type ArtworkReactionAggregate = {
+  // 작품별 이모지 수: artworkId → { '❤️': 3, '😍': 1 }
+  reactionsMap: Map<string, Record<string, number>>;
+  // 작품별 내가 누른 이모지: artworkId → '❤️'
+  myReactionMap: Map<string, string>;
+};
+
+// 여러 작품의 이모지 반응을 한 번에 집계한다.
+// 전시 상세·내 작품·위시리스트 등 작품 목록이 있는 곳에서 공통으로 사용.
+export async function fetchArtworkReactions(
+  supabase: SupabaseServerClient,
+  artworkIds: string[],
+  currentUserId: string | null
+): Promise<ArtworkReactionAggregate> {
+  const reactionsMap = new Map<string, Record<string, number>>();
+  const myReactionMap = new Map<string, string>();
+
+  if (artworkIds.length === 0) {
+    return { reactionsMap, myReactionMap };
+  }
+
+  const { data } = await supabase
+    .from('artwork_reactions')
+    .select('artwork_id, user_id, emoji')
+    .in('artwork_id', artworkIds);
+
+  for (const row of data ?? []) {
+    const counts = reactionsMap.get(row.artwork_id) ?? {};
+    counts[row.emoji] = (counts[row.emoji] ?? 0) + 1;
+    reactionsMap.set(row.artwork_id, counts);
+    if (currentUserId && row.user_id === currentUserId) {
+      myReactionMap.set(row.artwork_id, row.emoji);
+    }
+  }
+
+  return { reactionsMap, myReactionMap };
+}

--- a/src/lib/artwork/reactions.ts
+++ b/src/lib/artwork/reactions.ts
@@ -23,10 +23,17 @@ export async function fetchArtworkReactions(
     return { reactionsMap, myReactionMap };
   }
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('artwork_reactions')
     .select('artwork_id, user_id, emoji')
     .in('artwork_id', artworkIds);
+
+  // 반응은 부가 기능이므로 조회 실패 시 페이지 전체를 막지 않고
+  // 빈 집계를 반환한다. (에러는 로깅하여 추적 가능하게)
+  if (error) {
+    console.error('artwork reactions 집계 실패:', error);
+    return { reactionsMap, myReactionMap };
+  }
 
   for (const row of data ?? []) {
     const counts = reactionsMap.get(row.artwork_id) ?? {};

--- a/src/lib/artwork/service.ts
+++ b/src/lib/artwork/service.ts
@@ -75,6 +75,31 @@ export async function likesToggle(exhibitionId: string, closestId: string) {
   return result.json();
 }
 
+// 작품 이모지 반응 (4종)
+export const REACTION_EMOJIS = ['❤️', '😍', '😮', '👏'] as const;
+
+// 반응 토글: 같은 이모지 → 해제, 다른 이모지 → 교체. 응답의 emoji가 최종 상태
+export async function toggleReaction(
+  exhibitionId: string,
+  artworkId: string,
+  emoji: string
+): Promise<{ emoji: string | null }> {
+  const res = await fetch(
+    `/api/exhibitions/${exhibitionId}/artworks/${artworkId}/reactions`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ emoji }),
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error('request failed');
+  }
+
+  return res.json();
+}
+
 export const toggleArtworkLike = async (
   exhibitionId: string,
   artworkId: string,

--- a/src/lib/exhibition/server.ts
+++ b/src/lib/exhibition/server.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { createClient } from '@/lib/supabase/server';
 import { getAuthContext } from '@/lib/auth/getAuthContext';
+import { fetchArtworkReactions } from '@/lib/artwork/reactions';
 import {
   ArtworkRow,
   ExhibitionDetailRow,
@@ -191,6 +192,9 @@ export type ExhibitionWorkItem = {
   likes: number;
   liked: boolean;
   videoUrl: string | null;
+  // 이모지별 반응 수 (예: { '❤️': 3, '😍': 1 })와 내가 누른 반응
+  reactions: Record<string, number>;
+  myReaction: string | null;
 };
 
 export type ExhibitionDetailItem = {
@@ -278,6 +282,13 @@ export async function fetchExhibitionDetail(
     }
   }
 
+  // 작품 이모지 반응 집계 (공통 헬퍼 재사용)
+  const { reactionsMap, myReactionMap } = await fetchArtworkReactions(
+    supabase,
+    artworkIds,
+    currentUserId
+  );
+
   const profile = Array.isArray(rawData.profile)
     ? rawData.profile[0]
     : rawData.profile;
@@ -304,6 +315,8 @@ export async function fetchExhibitionDetail(
       likes: likesCountMap.get(work.id) ?? 0,
       liked: likedArtworkIds.has(work.id),
       videoUrl: work.video_url ?? null,
+      reactions: reactionsMap.get(work.id) ?? {},
+      myReaction: myReactionMap.get(work.id) ?? null,
     })),
   };
 }

--- a/src/types/artwork.ts
+++ b/src/types/artwork.ts
@@ -12,6 +12,8 @@ export type Artwork = {
   likesCount: number;
   isLiked: boolean;
   createdAt: string; // ISO string
+  reactions: Record<string, number>;
+  myReaction: string | null;
 };
 
 export type ArtworkWithEmail = {

--- a/supabase/migration/0008_artwork_reactions.sql
+++ b/supabase/migration/0008_artwork_reactions.sql
@@ -1,0 +1,46 @@
+-- *** 현재 파일은 단순 기록용 파일입니다. ***
+-- supabase에서 해당 sql을 추가하였고 무엇이 추가되었는지 공유용으로 만든 파일입니다.
+
+-- 작품 이모지 반응 기능용 마이그레이션
+-- 좋아요(artwork_likes)와 별개로, 작품마다 다양한 긍정 반응을 남긴다.
+-- 한 유저는 작품당 반응 1개만 가질 수 있고(다른 이모지 선택 시 교체),
+-- 구조는 좋아요와 동일한 (user, artwork) 매핑 + emoji 컬럼이다.
+
+-- 1) 반응 기록 테이블
+create table if not exists artwork_reactions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  artwork_id uuid not null references artworks(id) on delete cascade,
+  emoji text not null,
+  created_at timestamptz not null default now(),
+  -- 한 유저당 작품마다 반응 1개 (UPSERT 시 emoji 교체)
+  unique (user_id, artwork_id)
+);
+
+-- 2) 작품별 반응 집계용 인덱스
+create index if not exists artwork_reactions_artwork_idx
+  on artwork_reactions (artwork_id);
+
+-- 3) RLS: 조회는 누구나(집계 표시용), 쓰기는 본인 것만
+alter table artwork_reactions enable row level security;
+
+-- 모든 사용자가 반응 집계를 볼 수 있도록 조회 허용
+create policy "select reactions"
+  on artwork_reactions for select
+  using (true);
+
+-- 본인 반응 추가
+create policy "insert own reactions"
+  on artwork_reactions for insert
+  with check (auth.uid() = user_id);
+
+-- 본인 반응 변경(이모지 교체)
+create policy "update own reactions"
+  on artwork_reactions for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- 본인 반응 삭제(반응 해제)
+create policy "delete own reactions"
+  on artwork_reactions for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## 📌 개요

기존 작품 반응 표현은 좋아요 하나뿐이었습니다. 아이들의 그림에 멋져요/놀라워요/대단해요 같은 다양한 긍정 반응을 남길 수 있도록 이모지 반응 기능을 추가합니다. 그림을 그린 아이에게 더 직접적이고, 큰 응원이 되고 관람 참여를 풍부하게 합니다.

## 🔍 변경 사항

- **DB/API**
  - artwork_reactions 테이블 추가
  - 반응 토글 API 추가, 이미 누른 이모지 누르면 해제 / 다른 이모지 누르면 교체, 작품-전시회 소속 검증
    
- **서버 집계**
  - 반응 공통 `fetchArtworkReactions` 추출 -> 전시 상세, 내 작품 모아보기, 위시리스트 3곳에서 재사용 (좋아요 집계 패턴 미러링)
- **UI**
  - 이모지 4종(❤️😍😮👏) + 카운트 + 내 반응 하이라이트
  - WorkDialog, ArtworkModal에 낙관적 업데이트(실패 시 롤백) 연결

## 🔗 관련 이슈 번호

close #180 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1512" height="760" alt="스크린샷 2026-06-15 오후 12 32 20" src="https://github.com/user-attachments/assets/06be14e4-b200-4e5b-943a-0c4b58f937b2" />
<img width="1512" height="760" alt="스크린샷 2026-06-15 오후 12 32 46" src="https://github.com/user-attachments/assets/ff9a17ce-f843-4f88-b9dd-b3949438bff8" />


## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- DB 마이그레이션(`0008_artwork_reactions.sql`)은 Supabase에 적용되어 있습니다. (파일은 기록용, 추가 작업 불필요)
- 기존 좋아요(artwork_likes)와 완전히 별개 테이블/로직이라서 전시회 인기순 정렬, 집계에는 영향 없습니다.
