### PR TITLE
[PR] 고정 프리셋 선택시 프리셋이 문자열로 저장되는 버그 수정

### DIFF
--- a/src/app/api/exhibitions/route.ts
+++ b/src/app/api/exhibitions/route.ts
@@ -116,7 +116,7 @@ export async function POST(req: NextRequest) {
         ]);
       }
     } else if (userPreset) {
-      gallery_preset = userPreset;
+      gallery_preset = JSON.parse(userPreset);
     }
 
     console.log(gallery_preset);

--- a/src/app/api/exhibitions/route.ts
+++ b/src/app/api/exhibitions/route.ts
@@ -99,24 +99,19 @@ export async function POST(req: NextRequest) {
     } = result.data;
 
     if (thumbnailImg instanceof File) {
-      if (userPreset) {
-        thumbnailUrl = await uploadImgToSupabase(
-          supabase,
-          thumbnailImg,
-          'thumbnails'
-        );
-        gallery_preset = userPreset;
-      } else {
-        [thumbnailUrl, gallery_preset] = await Promise.all([
-          uploadImgToSupabase(supabase, thumbnailImg, 'thumbnails'),
-          generatePresetFromImageFile(thumbnailImg).catch((e) => {
-            console.log(e);
-            return defaultPreset;
-          }),
-        ]);
-      }
-    } else if (userPreset) {
-      gallery_preset = JSON.parse(userPreset);
+      thumbnailUrl = await uploadImgToSupabase(
+        supabase,
+        thumbnailImg,
+        'thumbnails'
+      );
+      gallery_preset =
+        userPreset ??
+        (await generatePresetFromImageFile(thumbnailImg).catch((e) => {
+          console.log(e);
+          return defaultPreset;
+        }));
+    } else {
+      gallery_preset = userPreset ?? defaultPreset;
     }
 
     console.log(gallery_preset);

--- a/src/lib/gallery/validateExhibitionForm.ts
+++ b/src/lib/gallery/validateExhibitionForm.ts
@@ -25,7 +25,7 @@ export function validateExhibition(init: Record<string, unknown>) {
       start_date: new Date(startDateRaw),
       end_date: endDateRaw ? new Date(endDateRaw) : null,
       guidelines: guidelines ?? null,
-      gallery_preset,
+      gallery_preset: gallery_preset ? JSON.parse(gallery_preset) : null,
     },
   };
 }


### PR DESCRIPTION
## 📌 개요

전시회 생성 시 고정 프리셋이 문자열로 저장되어 전시관테마가 적용되지 않는 문제를 해결했습니다.

## 🔍 변경 사항

ai생성테마의경우 api 라우트에서  generatePresetFromImageFile 메서드를 통해 전달받은 object타입을 그대로 db에 전달합니다
그러나 고정 테마의 경우 클라이언트에서 폼 데이터로 넘겨줘야하기때문에 직렬화를 하는데 기존에는 이 직렬화 한 값을 그대로 db에 전달했기떄문에 문제가 발생했습니다. 따라서 고정테마일경우  클라에서 전달받은 프리셋을  api라우트에서 파싱 후 db에 넘겨주도록 수정했습니다.

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #193 

## 📸 스크린샷 (UI 변경 시 필수)

> 변경된 UI 스크린샷을 보여주세요.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
