### PR TITLE
[PR] Image2Video 모델 업그레이드

### DIFF
--- a/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
@@ -69,19 +69,16 @@ export async function POST(
         cost: CREDIT_COSTS.animate,
         ref: randomUUID(),
         run: async () => {
-          const result = await fal.subscribe(
-            'fal-ai/wan/v2.7/image-to-video',
-            {
-              input: {
-                image_url: artwork.image_url,
-                prompt:
-                  "A children's hand-drawn illustration comes to life with soft, looping animation. The main subject gently moves: characters walk in place or sway, animals breathe and blink, plants and trees rustle slowly, water ripples calmly. Background elements move subtly at a slower pace than foreground. Strictly preserve the original flat 2D illustration style, crayon and paint textures, and color palette. Characters maintain their original shape and proportions throughout. No photorealism. No camera movement. Smooth, cute, cheerful motion.",
-                negative_prompt:
-                  'photorealistic, 3D render, morphing, warping, distortion, flickering, camera pan, camera zoom, blurry, deformed characters, style change',
-                resolution: '1080p',
-              },
-            }
-          );
+          const result = await fal.subscribe('fal-ai/wan/v2.7/image-to-video', {
+            input: {
+              image_url: artwork.image_url,
+              prompt:
+                "A children's hand-drawn illustration comes to life with soft, looping animation. The main subject gently moves: characters walk in place or sway, animals breathe and blink, plants and trees rustle slowly, water ripples calmly. Background elements move subtly at a slower pace than foreground. Strictly preserve the original flat 2D illustration style, crayon and paint textures, and color palette. Characters maintain their original shape and proportions throughout. No photorealism. No camera movement. Smooth, cute, cheerful motion.",
+              negative_prompt:
+                'photorealistic, 3D render, morphing, warping, distortion, flickering, camera pan, camera zoom, blurry, deformed characters, style change',
+              resolution: '1080p',
+            },
+          });
 
           const url = (result.data as { video?: { url?: string } })?.video?.url;
           if (!url) {

--- a/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
+++ b/src/app/api/exhibitions/[exhibitionId]/artworks/[artworksId]/animate/route.ts
@@ -9,7 +9,7 @@ import {
   CREDIT_COSTS,
 } from '@/lib/payments/credit';
 
-export const maxDuration = 180;
+export const maxDuration = 300;
 
 fal.config({ credentials: process.env.FALAI_API_KEY });
 
@@ -70,7 +70,7 @@ export async function POST(
         ref: randomUUID(),
         run: async () => {
           const result = await fal.subscribe(
-            'fal-ai/wan-25-preview/image-to-video',
+            'fal-ai/wan/v2.7/image-to-video',
             {
               input: {
                 image_url: artwork.image_url,
@@ -78,7 +78,7 @@ export async function POST(
                   "A children's hand-drawn illustration comes to life with soft, looping animation. The main subject gently moves: characters walk in place or sway, animals breathe and blink, plants and trees rustle slowly, water ripples calmly. Background elements move subtly at a slower pace than foreground. Strictly preserve the original flat 2D illustration style, crayon and paint textures, and color palette. Characters maintain their original shape and proportions throughout. No photorealism. No camera movement. Smooth, cute, cheerful motion.",
                 negative_prompt:
                   'photorealistic, 3D render, morphing, warping, distortion, flickering, camera pan, camera zoom, blurry, deformed characters, style change',
-                resolution: '480p',
+                resolution: '1080p',
               },
             }
           );

--- a/src/components/ui/ArtworkDetailContent.tsx
+++ b/src/components/ui/ArtworkDetailContent.tsx
@@ -146,6 +146,25 @@ export default function ArtworkDetailContent({
               {showVideo ? '🖼 이미지 보기' : '▶ 영상 보기'}
             </button>
           )}
+
+          {/* 영상 생성 대기 로딩 오버레이 (~1-2분 소요) */}
+          {isAnimating && (
+            <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-white/80 px-6 text-center backdrop-blur-sm">
+              <div className="relative flex h-14 w-14 items-center justify-center">
+                <span className="absolute inset-0 animate-ping rounded-full bg-purple-300/50" />
+                <span className="absolute inset-1.5 rounded-full bg-purple-100" />
+                <span className="relative animate-pulse text-2xl">✨</span>
+              </div>
+              <p className="text-[14px] font-bold text-purple-700">
+                작품을 영상으로 만들고 있어요
+              </p>
+              <p className="text-[12px] leading-relaxed text-[#6b6b6b]">
+                보통 1~2분 정도 걸려요.
+                <br />
+                창을 닫지 말고 잠시만 기다려 주세요.
+              </p>
+            </div>
+          )}
         </div>
 
         {/* 정보 패널 */}


### PR DESCRIPTION
## 📌 개요

AI 영상 변환 모델이 Wan 2.5 preview + 480p라 아이들의 작품을 영상으로 만들 때 해상도가 낮아 디테일이 뭉개졌습니다. 
최신 Wan 2.7 + 1080p 모델로 업그레이드하여 영상 퀄리티를 높였습니다. 
fal 단가 차이로 1080p 처리 시간이 늘어 함수 타임아웃도 상향했습니다.(약 90~100초 정도 소요)
또한 생성 대기 시간이 길어진 만큼, 기다리는 동안의 로딩 UI를 추가해 사용자 경험을 보완했습니다.

## 🔍 변경 사항

- i2v 모델 교체: `fal-ai/wan-25-preview/image-to-video` → `fal-ai/wan/v2.7/image-to-video`

- 출력 해상도 480p → 1080p
- `maxDuration` 180s → 300s (1080p 처리 시간 편차 대비)
- 영상 생성 대기 로딩 오버레이 추가 (작품 이미지 위에 진행 안내 + 애니메이션)

## 🔗 관련 이슈 번호

close #206 

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경 없습니다.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요? (dev에서 i2v 실생성 성공, 96초)
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요? (build 통과)

## 🚩 기타 참고 사항

x