### PR TITLE
[PR] 3D 전시관 렌더링 최적화

### DIFF
--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -110,9 +110,11 @@ export default function Painting({
   }, [videoUrl]);
 
   useFrame(({ camera, clock }) => {
+    if (!videoUrl) return;
+
     // 영상 작품 프레임: 빛 띠(그라데이션)가 프레임을 따라 흐르고
     // 전체 밝기도 은은하게 맥동
-    if (videoUrl && frameMatRef.current) {
+    if (frameMatRef.current) {
       const t = clock.elapsedTime;
       if (sweepTextureRef.current) {
         sweepTextureRef.current.offset.x = -t * 0.3;

--- a/src/components/exhibition-gallery/threejs/Scene.tsx
+++ b/src/components/exhibition-gallery/threejs/Scene.tsx
@@ -121,6 +121,7 @@ export default function Scene2({
     <Canvas
       shadows="percentage"
       camera={{ fov: 65 }}
+      dpr={[1, 1.5]}
       gl={{
         antialias: true,
         preserveDrawingBuffer: true,
@@ -144,28 +145,28 @@ export default function Scene2({
                 position={[-40, 24, -50]}
                 speed={0.04}
                 opacity={0.7}
-                segments={40}
+                segments={20}
                 bounds={[18, 4, 8]}
               />
               <Cloud
                 position={[-46, 26, -48]}
                 speed={0.03}
                 opacity={0.45}
-                segments={25}
+                segments={15}
                 bounds={[10, 3, 5]}
               />
               <Cloud
                 position={[45, 22, 30]}
                 speed={0.05}
                 opacity={0.65}
-                segments={45}
+                segments={20}
                 bounds={[20, 5, 9]}
               />
               <Cloud
                 position={[50, 25, 28]}
                 speed={0.04}
                 opacity={0.4}
-                segments={20}
+                segments={10}
                 bounds={[8, 3, 4]}
               />
             </>
@@ -210,7 +211,7 @@ export default function Scene2({
         intensity={lighting.directional.intensity}
         color={lighting.directional.color}
         castShadow
-        shadow-mapSize={[2048, 2048]}
+        shadow-mapSize={[1024, 1024]}
         shadow-radius={20}
         shadow-bias={-0.001}
         shadow-normalBias={0.04}

--- a/src/components/exhibition-gallery/threejs/particles/Bubbles.tsx
+++ b/src/components/exhibition-gallery/threejs/particles/Bubbles.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Mesh } from 'three';
 
@@ -22,42 +22,6 @@ type BubbleState = {
   initialT: number;
 };
 
-function SingleBubble({
-  state,
-  height,
-  color,
-  opacity,
-}: {
-  state: BubbleState;
-  height: number;
-  color: string;
-  opacity: number;
-}) {
-  const ref = useRef<Mesh>(null);
-  const y = useRef(state.startY);
-  const t = useRef(state.initialT);
-
-  useFrame((_, delta) => {
-    if (!ref.current) return;
-    y.current += state.speed * delta;
-    t.current += delta * 0.5;
-
-    if (y.current > height) y.current = 0;
-
-    ref.current.position.x = state.x + Math.sin(t.current + state.driftX) * 0.4;
-    ref.current.position.y = y.current;
-    ref.current.position.z =
-      state.z + Math.cos(t.current * 0.7 + state.driftZ) * 0.4;
-  });
-
-  return (
-    <mesh ref={ref} position={[state.x, state.startY, state.z]}>
-      <sphereGeometry args={[state.size, 12, 12]} />
-      <meshBasicMaterial color={color} transparent opacity={opacity} />
-    </mesh>
-  );
-}
-
 export default function Bubbles({
   count = 30,
   size,
@@ -75,7 +39,7 @@ export default function Bubbles({
 }) {
   const half = size / 2;
 
-  const bubbles = useMemo(
+  const bubbles = useMemo<BubbleState[]>(
     () =>
       Array.from({ length: count }, (_, i) => ({
         x: rr(i * 6, -half, half),
@@ -90,16 +54,47 @@ export default function Bubbles({
     [count, half, height, speed]
   );
 
+  const meshRefs = useRef<(Mesh | null)[]>([]);
+  const yState = useRef<number[]>([]);
+  const tState = useRef<number[]>([]);
+
+  useEffect(() => {
+    yState.current = bubbles.map((b) => b.startY);
+    tState.current = bubbles.map((b) => b.initialT);
+  }, [bubbles]);
+
+  useFrame((_, delta) => {
+    for (let i = 0; i < bubbles.length; i++) {
+      const mesh = meshRefs.current[i];
+      if (!mesh) continue;
+      const s = bubbles[i];
+
+      yState.current[i] += s.speed * delta;
+      tState.current[i] += delta * 0.5;
+
+      if (yState.current[i] > height) yState.current[i] = 0;
+
+      const y = yState.current[i];
+      const t = tState.current[i];
+      mesh.position.x = s.x + Math.sin(t + s.driftX) * 0.4;
+      mesh.position.y = y;
+      mesh.position.z = s.z + Math.cos(t * 0.7 + s.driftZ) * 0.4;
+    }
+  });
+
   return (
     <>
       {bubbles.map((state, i) => (
-        <SingleBubble
+        <mesh
           key={i}
-          state={state}
-          height={height}
-          color={color}
-          opacity={opacity}
-        />
+          ref={(el) => {
+            meshRefs.current[i] = el;
+          }}
+          position={[state.x, state.startY, state.z]}
+        >
+          <sphereGeometry args={[state.size, 12, 12]} />
+          <meshBasicMaterial color={color} transparent opacity={opacity} />
+        </mesh>
       ))}
     </>
   );

--- a/src/components/exhibition-gallery/threejs/particles/FallingLeaves.tsx
+++ b/src/components/exhibition-gallery/threejs/particles/FallingLeaves.tsx
@@ -17,7 +17,6 @@ function rr(seed: number, min: number, max: number): number {
   return min + sr(seed) * (max - min);
 }
 
-/** 초록 → 단풍(갈색/주황) 잎 색 팔레트 */
 const LEAF_COLORS = ['#6BA34A', '#4F8C3A', '#C9882E', '#B5651D', '#D9A441'];
 
 type LeafState = {
@@ -32,43 +31,6 @@ type LeafState = {
   initialRotY: number;
   colorIndex: number;
 };
-
-function SingleLeaf({
-  state,
-  height,
-  geometry,
-  material,
-}: {
-  state: LeafState;
-  height: number;
-  geometry: ShapeGeometry;
-  material: MeshStandardMaterial;
-}) {
-  const ref = useRef<Group>(null);
-  const y = useRef(state.startY);
-  const rotY = useRef(state.initialRotY);
-
-  useFrame((_, delta) => {
-    if (!ref.current) return;
-    y.current -= state.speed * delta;
-    rotY.current += state.rotSpeed * delta;
-
-    if (y.current < -0.5) y.current = height + rr(y.current * 1000, 0, height);
-
-    ref.current.position.x = state.x + Math.sin(y.current * 0.5) * state.driftX;
-    ref.current.position.y = y.current;
-    ref.current.position.z = state.z + Math.cos(y.current * 0.4) * state.driftZ;
-    ref.current.rotation.y = rotY.current;
-    ref.current.rotation.x = Math.sin(y.current * 0.7) * 0.6;
-    ref.current.rotation.z = Math.cos(y.current * 0.5) * 0.4;
-  });
-
-  return (
-    <group ref={ref} scale={state.scale}>
-      <mesh geometry={geometry} material={material} castShadow />
-    </group>
-  );
-}
 
 export default function FallingLeaves({
   count = 40,
@@ -114,7 +76,7 @@ export default function FallingLeaves({
     [geometry, materials]
   );
 
-  const leaves = useMemo(
+  const leaves = useMemo<LeafState[]>(
     () =>
       Array.from({ length: count }, (_, i) => ({
         x: rr(i * 7, -half, half),
@@ -131,16 +93,54 @@ export default function FallingLeaves({
     [count, half, height, speed]
   );
 
+  const groupRefs = useRef<(Group | null)[]>([]);
+  const yState = useRef<number[]>([]);
+  const rotYState = useRef<number[]>([]);
+
+  useEffect(() => {
+    yState.current = leaves.map((l) => l.startY);
+    rotYState.current = leaves.map((l) => l.initialRotY);
+  }, [leaves]);
+
+  useFrame((_, delta) => {
+    for (let i = 0; i < leaves.length; i++) {
+      const group = groupRefs.current[i];
+      if (!group) continue;
+      const s = leaves[i];
+
+      yState.current[i] -= s.speed * delta;
+      rotYState.current[i] += s.rotSpeed * delta;
+
+      if (yState.current[i] < -0.5) {
+        yState.current[i] = height + rr(yState.current[i] * 1000, 0, height);
+      }
+
+      const y = yState.current[i];
+      group.position.x = s.x + Math.sin(y * 0.5) * s.driftX;
+      group.position.y = y;
+      group.position.z = s.z + Math.cos(y * 0.4) * s.driftZ;
+      group.rotation.y = rotYState.current[i];
+      group.rotation.x = Math.sin(y * 0.7) * 0.6;
+      group.rotation.z = Math.cos(y * 0.5) * 0.4;
+    }
+  });
+
   return (
     <>
       {leaves.map((state, i) => (
-        <SingleLeaf
+        <group
           key={i}
-          state={state}
-          height={height}
-          geometry={geometry}
-          material={materials[state.colorIndex]}
-        />
+          ref={(el) => {
+            groupRefs.current[i] = el;
+          }}
+          scale={state.scale}
+        >
+          <mesh
+            geometry={geometry}
+            material={materials[state.colorIndex]}
+            castShadow
+          />
+        </group>
       ))}
     </>
   );

--- a/src/components/exhibition-gallery/threejs/particles/FallingPetals.tsx
+++ b/src/components/exhibition-gallery/threejs/particles/FallingPetals.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Group } from 'three';
 import { FlowerPetal } from '../../models/basic/FlowerPetal';
@@ -24,32 +24,6 @@ type PetalState = {
   initialRotY: number;
 };
 
-function SinglePetal({ state, height }: { state: PetalState; height: number }) {
-  const ref = useRef<Group>(null);
-  const y = useRef(state.startY);
-  const rotY = useRef(state.initialRotY);
-
-  useFrame((_, delta) => {
-    if (!ref.current) return;
-    y.current -= state.speed * delta;
-    rotY.current += state.rotSpeed * delta;
-
-    if (y.current < -0.5) y.current = height + rr(y.current * 1000, 0, height);
-
-    ref.current.position.x = state.x + Math.sin(y.current * 0.5) * state.driftX;
-    ref.current.position.y = y.current;
-    ref.current.position.z = state.z + Math.cos(y.current * 0.4) * state.driftZ;
-    ref.current.rotation.y = rotY.current;
-    ref.current.rotation.x = Math.sin(y.current * 0.7) * 0.4;
-  });
-
-  return (
-    <group ref={ref} scale={state.scale}>
-      <FlowerPetal />
-    </group>
-  );
-}
-
 export default function FallingPetals({
   count = 30,
   size,
@@ -63,7 +37,7 @@ export default function FallingPetals({
 }) {
   const half = size / 2 - 0.5;
 
-  const petals = useMemo(
+  const petals = useMemo<PetalState[]>(
     () =>
       Array.from({ length: count }, (_, i) => ({
         x: rr(i * 7, -half, half),
@@ -79,10 +53,49 @@ export default function FallingPetals({
     [count, half, height, speed]
   );
 
+  const groupRefs = useRef<(Group | null)[]>([]);
+  const yState = useRef<number[]>([]);
+  const rotYState = useRef<number[]>([]);
+
+  useEffect(() => {
+    yState.current = petals.map((p) => p.startY);
+    rotYState.current = petals.map((p) => p.initialRotY);
+  }, [petals]);
+
+  useFrame((_, delta) => {
+    for (let i = 0; i < petals.length; i++) {
+      const group = groupRefs.current[i];
+      if (!group) continue;
+      const s = petals[i];
+
+      yState.current[i] -= s.speed * delta;
+      rotYState.current[i] += s.rotSpeed * delta;
+
+      if (yState.current[i] < -0.5) {
+        yState.current[i] = height + rr(yState.current[i] * 1000, 0, height);
+      }
+
+      const y = yState.current[i];
+      group.position.x = s.x + Math.sin(y * 0.5) * s.driftX;
+      group.position.y = y;
+      group.position.z = s.z + Math.cos(y * 0.4) * s.driftZ;
+      group.rotation.y = rotYState.current[i];
+      group.rotation.x = Math.sin(y * 0.7) * 0.4;
+    }
+  });
+
   return (
     <>
       {petals.map((state, i) => (
-        <SinglePetal key={i} state={state} height={height} />
+        <group
+          key={i}
+          ref={(el) => {
+            groupRefs.current[i] = el;
+          }}
+          scale={state.scale}
+        >
+          <FlowerPetal />
+        </group>
       ))}
     </>
   );

--- a/src/components/exhibition-gallery/threejs/particles/FallingSnow.tsx
+++ b/src/components/exhibition-gallery/threejs/particles/FallingSnow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Mesh } from 'three';
 
@@ -22,42 +22,6 @@ type SnowState = {
   initialT: number;
 };
 
-function SingleFlake({
-  state,
-  height,
-  color,
-  opacity,
-}: {
-  state: SnowState;
-  height: number;
-  color: string;
-  opacity: number;
-}) {
-  const ref = useRef<Mesh>(null);
-  const y = useRef(state.startY);
-  const t = useRef(state.initialT);
-
-  useFrame((_, delta) => {
-    if (!ref.current) return;
-    y.current -= state.speed * delta;
-    t.current += delta * 0.5;
-
-    if (y.current < 0) y.current = height;
-
-    ref.current.position.x = state.x + Math.sin(t.current + state.driftX) * 0.3;
-    ref.current.position.y = y.current;
-    ref.current.position.z =
-      state.z + Math.cos(t.current * 0.7 + state.driftZ) * 0.3;
-  });
-
-  return (
-    <mesh ref={ref} position={[state.x, state.startY, state.z]}>
-      <sphereGeometry args={[state.size, 8, 8]} />
-      <meshBasicMaterial color={color} transparent opacity={opacity} />
-    </mesh>
-  );
-}
-
 export default function FallingSnow({
   count = 60,
   size,
@@ -75,7 +39,7 @@ export default function FallingSnow({
 }) {
   const half = size / 2;
 
-  const flakes = useMemo(
+  const flakes = useMemo<SnowState[]>(
     () =>
       Array.from({ length: count }, (_, i) => ({
         x: rr(i * 6, -half, half),
@@ -90,16 +54,47 @@ export default function FallingSnow({
     [count, half, height, speed]
   );
 
+  const meshRefs = useRef<(Mesh | null)[]>([]);
+  const yState = useRef<number[]>([]);
+  const tState = useRef<number[]>([]);
+
+  useEffect(() => {
+    yState.current = flakes.map((f) => f.startY);
+    tState.current = flakes.map((f) => f.initialT);
+  }, [flakes]);
+
+  useFrame((_, delta) => {
+    for (let i = 0; i < flakes.length; i++) {
+      const mesh = meshRefs.current[i];
+      if (!mesh) continue;
+      const s = flakes[i];
+
+      yState.current[i] -= s.speed * delta;
+      tState.current[i] += delta * 0.5;
+
+      if (yState.current[i] < 0) yState.current[i] = height;
+
+      const y = yState.current[i];
+      const t = tState.current[i];
+      mesh.position.x = s.x + Math.sin(t + s.driftX) * 0.3;
+      mesh.position.y = y;
+      mesh.position.z = s.z + Math.cos(t * 0.7 + s.driftZ) * 0.3;
+    }
+  });
+
   return (
     <>
       {flakes.map((state, i) => (
-        <SingleFlake
+        <mesh
           key={i}
-          state={state}
-          height={height}
-          color={color}
-          opacity={opacity}
-        />
+          ref={(el) => {
+            meshRefs.current[i] = el;
+          }}
+          position={[state.x, state.startY, state.z]}
+        >
+          <sphereGeometry args={[state.size, 8, 8]} />
+          <meshBasicMaterial color={color} transparent opacity={opacity} />
+        </mesh>
       ))}
     </>
   );

--- a/src/components/exhibition-gallery/threejs/particles/RainDrops.tsx
+++ b/src/components/exhibition-gallery/threejs/particles/RainDrops.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Mesh } from 'three';
 
@@ -19,37 +19,6 @@ type DropState = {
   windX: number;
 };
 
-function SingleDrop({
-  state,
-  height,
-  color,
-  opacity,
-}: {
-  state: DropState;
-  height: number;
-  color: string;
-  opacity: number;
-}) {
-  const ref = useRef<Mesh>(null);
-  const y = useRef(state.startY);
-
-  useFrame((_, delta) => {
-    if (!ref.current) return;
-    y.current -= state.speed * delta;
-    if (y.current < 0) y.current = height;
-    ref.current.position.y = y.current;
-    ref.current.position.x =
-      state.x + (height - y.current) * state.windX * 0.04;
-  });
-
-  return (
-    <mesh ref={ref} position={[state.x, state.startY, state.z]}>
-      <cylinderGeometry args={[0.012, 0.004, 0.22, 3]} />
-      <meshBasicMaterial color={color} transparent opacity={opacity} />
-    </mesh>
-  );
-}
-
 export default function RainDrops({
   count = 200,
   size,
@@ -67,7 +36,7 @@ export default function RainDrops({
 }) {
   const half = size / 2;
 
-  const drops = useMemo(
+  const drops = useMemo<DropState[]>(
     () =>
       Array.from({ length: count }, (_, i) => ({
         x: rr(i * 5, -half, half),
@@ -79,16 +48,41 @@ export default function RainDrops({
     [count, half, height, speed]
   );
 
+  const meshRefs = useRef<(Mesh | null)[]>([]);
+  const yState = useRef<number[]>([]);
+
+  useEffect(() => {
+    yState.current = drops.map((d) => d.startY);
+  }, [drops]);
+
+  useFrame((_, delta) => {
+    for (let i = 0; i < drops.length; i++) {
+      const mesh = meshRefs.current[i];
+      if (!mesh) continue;
+      const s = drops[i];
+
+      yState.current[i] -= s.speed * delta;
+      if (yState.current[i] < 0) yState.current[i] = height;
+
+      const y = yState.current[i];
+      mesh.position.y = y;
+      mesh.position.x = s.x + (height - y) * s.windX * 0.04;
+    }
+  });
+
   return (
     <>
       {drops.map((state, i) => (
-        <SingleDrop
+        <mesh
           key={i}
-          state={state}
-          height={height}
-          color={color}
-          opacity={opacity}
-        />
+          ref={(el) => {
+            meshRefs.current[i] = el;
+          }}
+          position={[state.x, state.startY, state.z]}
+        >
+          <cylinderGeometry args={[0.012, 0.004, 0.22, 3]} />
+          <meshBasicMaterial color={color} transparent opacity={opacity} />
+        </mesh>
       ))}
     </>
   );


### PR DESCRIPTION
## 📌 개요

3D 전시관에서 파티클 효과 사용 시 렌더링 버벅임이 발생했습니다. 파티클 컴포넌트들이 각 입자마다 개별 `useFrame`을 등록해 매 프레임 최대 200개 콜백이 실행되는 구조가 원인인 것으로 확인됐습니다. 그래서 단일 `useFrame` + 배열 순회로 통합해 콜백 수를 대폭 감소했습니다.

## 🔍 변경 사항

- `FallingPetals` / `FallingSnow` / `FallingLeaves` / `Bubbles` / `RainDrops`: 각 입자 컴포넌트의 개별 `useFrame` 제거, 부모에서 단일 `useFrame`으로 통합 (최대 200개 -> 1개)
- `Painting`: 영상 변환 작품이 아닌 경우 `useFrame` 상단에서 early return 추가
- `Scene`: `dpr={[1, 1.5]}` 추가(레티나 렌더 부하 감소), `shadow-mapSize` 2048 → 1024, Cloud `segments` 축소

## 🔗 관련 이슈 번호

close #210

## 📸 스크린샷 (UI 변경 시 필수)

변경 없습니다.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

- `preserveDrawingBuffer: true`는 `5`키 스크린샷 기능(`canvas.toDataURL`)에 의존하므로 유지합니다.
- 파티클 애니메이션 동작은 기존과 동일하나, 상태 배열(`yState`, `rotYState` 등)이 `useEffect`로 초기화되므로 첫 프레임 전 마운트 완료 필요 (정상 동작 확인됨)
