### PR TITLE
[PR] 영상 작품 표시 배지 벽 투과 버그

### DIFF
--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -12,7 +12,7 @@ import {
 } from 'three';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
-import { Download, Heart, Play } from 'lucide-react';
+import { Download, Heart } from 'lucide-react';
 import { checkImgSize } from '@/lib/gallery/image';
 import { GalleryUIArtworkProps } from '@/types/gallery';
 
@@ -41,6 +41,31 @@ function createGoldSweepTexture() {
   const tex = new CanvasTexture(canvas);
   tex.wrapS = RepeatWrapping;
   tex.wrapT = RepeatWrapping;
+  return tex;
+}
+
+// 영상 작품 ▶ 배지 텍스처 (원형 + 흰 삼각형). 모든 작품이 공유 — 1회만 생성
+let playBadgeTexture: CanvasTexture | null = null;
+function getPlayBadgeTexture() {
+  if (playBadgeTexture) return playBadgeTexture;
+  const canvas = document.createElement('canvas');
+  canvas.width = 64;
+  canvas.height = 64;
+  const ctx = canvas.getContext('2d')!;
+  ctx.beginPath();
+  ctx.arc(32, 32, 30, 0, Math.PI * 2);
+  ctx.fillStyle = 'rgba(0,0,0,0.5)';
+  ctx.fill();
+  ctx.beginPath();
+  ctx.moveTo(26, 19);
+  ctx.lineTo(47, 32);
+  ctx.lineTo(26, 45);
+  ctx.closePath();
+  ctx.fillStyle = '#ffffff';
+  ctx.fill();
+  const tex = new CanvasTexture(canvas);
+  tex.colorSpace = SRGBColorSpace;
+  playBadgeTexture = tex;
   return tex;
 }
 
@@ -204,21 +229,18 @@ export default function Painting({
         <meshStandardMaterial map={img} />
       </mesh>
 
-      {/* 영상 변환 작품 ▶ 배지 — 액자 우하단 모서리 */}
+      {/* 영상 변환 작품 ▶ 배지 — 액자 우하단 모서리.
+          Html이 아닌 실제 3D 메시라 깊이 테스트로 벽이 자동으로 가림 (레이캐스팅 없음) */}
       {videoUrl && (
-        <Html
-          transform
-          occlude
-          position={[imgW / 2 + FRAME_M, -imgH / 2 - FRAME_M, 0.12]}
-          distanceFactor={2}
-          center
-          zIndexRange={[30, 0]}
-          style={{ pointerEvents: 'none' }}
-        >
-          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-black/45 backdrop-blur-sm">
-            <Play size={13} className="ml-0.5 fill-white text-white" />
-          </div>
-        </Html>
+        <mesh position={[imgW / 2 + FRAME_M, -imgH / 2 - FRAME_M, 0.12]}>
+          <planeGeometry args={[0.22, 0.22]} />
+          <meshBasicMaterial
+            map={getPlayBadgeTexture()}
+            transparent
+            depthWrite={false}
+            toneMapped={false}
+          />
+        </mesh>
       )}
 
       {/* 작품 정보 */}


### PR DESCRIPTION
## 📌 개요

3D 전시관에서 영상 변환 작품의 ▶ 배지가 벽 너머로 보이고, 영상 작품이 많아질수록 렌더링 버벅임(렉)이 심해지는 문제를 해결했습니다. 
배지가 drei `<Html occlude>`로 구현돼 매 프레임 레이캐스팅이 렉을 유발하고 가림 판정도 불안정해 벽 투과가 재발했습니다. 
때문에 영상 표시 배지를 실제 3D 메시로 바꿔 두 문제를 한 번에 해결했습니다.

## 🔍 변경 사항

- ▶ 배지를 `<Html transform occlude>` → 실제 3D 메시 평면으로 교체

- 공유 CanvasTexture(원형 + 흰 삼각형, 1회 생성) + `meshBasicMaterial` 사용 → 작품마다 메시 1개, 레이캐스팅 없음
- 깊이 테스트로 벽이 자동으로 배지를 가림 (occlude 제거)
- 미사용 `Play` 아이콘 import 제거

## 🔗 관련 이슈 번호

close #211 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1534" height="796" alt="image" src="https://github.com/user-attachments/assets/0e298276-66ee-4a3c-9963-6564bc8f3798" />
<img width="1534" height="796" alt="image" src="https://github.com/user-attachments/assets/9c2955f6-fca0-43a2-8765-21d4e40769e0" />
<img width="1534" height="786" alt="image" src="https://github.com/user-attachments/assets/59716427-197e-4e34-a4f8-5d7f95aa1ba4" />



## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요? (배지 정상 표시, 벽 가림 확인)
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요? (build 통과)

## 🚩 기타 참고 사항

- 렌더링 버벅임 완전히 사라짐 (레이캐스팅 제거 효과)
- 작품 정보 Html(근접 시 표시)은 가림 이슈가 없어 그대로 유지
- 배지 텍스처는 모든 작품이 공유해 메모리/생성 비용 최소화
