### PR TITLE
[PR] 전시관 생성 테마선택 ui변경

### DIFF
--- a/src/components/exhibition-create/ThemeSelector.tsx
+++ b/src/components/exhibition-create/ThemeSelector.tsx
@@ -21,52 +21,59 @@ export default function ThemeSelector({
   hasThumb: boolean;
 }) {
   return (
-    <div className="flex flex-col gap-3">
-      <div className="grid grid-cols-5 gap-2">
-        {/* AI 자동 생성 카드 */}
+    <div className="flex flex-col gap-2.5">
+      <div className="flex flex-wrap items-center gap-2.5">
+        {/* AI 자동 생성 스와치 */}
         <button
           type="button"
           onClick={() => onChange(value === 'ai' ? null : 'ai')}
-          className={`flex flex-col overflow-hidden rounded-[10px] border-2 transition-all duration-150 ${
+          aria-label="AI 자동 생성"
+          title="AI 자동 생성"
+          className={`inline-flex h-9 items-center justify-center gap-1.5 rounded-full transition-all duration-200 ${
             !hasThumb
-              ? 'cursor-not-allowed opacity-40'
+              ? 'w-9 cursor-not-allowed bg-linear-to-br from-violet-400 to-indigo-500 opacity-30'
               : value === 'ai'
-                ? 'border-primary shadow-md'
-                : 'border-transparent hover:border-gray-200'
+                ? 'bg-indigo-50 pr-3.5 pl-1.5 text-sm font-semibold text-indigo-600 ring-2 ring-indigo-500'
+                : 'w-9 bg-linear-to-br from-violet-400 to-indigo-500 hover:scale-110'
           }`}
           disabled={!hasThumb}
         >
-          <div className="flex h-11 w-full items-center justify-center bg-gradient-to-br from-violet-400 to-indigo-500">
-            <Wand2 className="h-5 w-5 text-white" />
-          </div>
-          <div className="w-full bg-indigo-50 px-1 py-[5px] text-center text-[10px] leading-tight font-semibold text-indigo-600">
-            AI 자동
-          </div>
+          {value === 'ai' ? (
+            <>
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-linear-to-br from-violet-400 to-indigo-500">
+                <Wand2 className="h-3.5 w-3.5 text-white" />
+              </span>
+              AI 자동
+            </>
+          ) : (
+            <Wand2 className="h-4 w-4 text-white" />
+          )}
         </button>
 
         {ALL_PRESETS.map((preset) => {
           const isSelected = value === preset.id;
+          const label = PRESET_LABELS[preset.id] ?? preset.id;
           return (
             <button
               key={preset.id}
               type="button"
               onClick={() => onChange(isSelected ? null : preset.id)}
-              className={`flex flex-col overflow-hidden rounded-[10px] border-2 transition-all duration-150 ${
+              aria-label={label}
+              title={label}
+              className={`inline-flex h-9 items-center gap-1.5 rounded-full transition-all duration-200 ${
                 isSelected
-                  ? 'border-primary shadow-md'
-                  : 'border-transparent hover:border-gray-200'
+                  ? 'bg-primary/10 text-primary ring-primary pr-3.5 pl-1.5 text-sm font-semibold ring-2'
+                  : 'w-9 ring-1 ring-black/10 hover:scale-110'
               }`}
+              style={isSelected ? undefined : { background: getCardBg(preset) }}
             >
-              <div
-                className="h-11 w-full"
-                style={{ background: getCardBg(preset) }}
-              />
-              <div
-                className="w-full px-1 py-[5px] text-center text-[10px] leading-tight font-semibold text-gray-700"
-                style={{ backgroundColor: preset.floor.color || '#fff' }}
-              >
-                {PRESET_LABELS[preset.id] ?? preset.id}
-              </div>
+              {isSelected && (
+                <span
+                  className="h-6 w-6 rounded-full ring-1 ring-black/10"
+                  style={{ background: getCardBg(preset) }}
+                />
+              )}
+              {isSelected && label}
             </button>
           );
         })}

--- a/src/components/exhibition-gallery/GalleryEntryModal.tsx
+++ b/src/components/exhibition-gallery/GalleryEntryModal.tsx
@@ -6,7 +6,7 @@ import { CharacterModel } from '@/hooks/usePlayerSocket';
 const MODELS: { value: CharacterModel; label: string; emoji: string }[] = [
   { value: 'human', label: '사람', emoji: '🧑' },
   { value: 'bunny', label: '토끼', emoji: '🐰' },
-  { value: 'cartoon', label: '카툰', emoji: '🎨' },
+  { value: 'cartoon', label: '여우', emoji: '🎨' },
 ];
 
 interface GalleryEntryModalProps {

--- a/src/components/exhibition-gallery/GalleryEntryModal.tsx
+++ b/src/components/exhibition-gallery/GalleryEntryModal.tsx
@@ -6,7 +6,7 @@ import { CharacterModel } from '@/hooks/usePlayerSocket';
 const MODELS: { value: CharacterModel; label: string; emoji: string }[] = [
   { value: 'human', label: '사람', emoji: '🧑' },
   { value: 'bunny', label: '토끼', emoji: '🐰' },
-  { value: 'cartoon', label: '여우', emoji: '🎨' },
+  { value: 'cartoon', label: '여우', emoji: '🦊' },
 ];
 
 interface GalleryEntryModalProps {


### PR DESCRIPTION
## 📌 개요

전시관 생성 화면의 테마 선택 UI(ThemeSelector)가 큰 색상 카드 그리드 형태여서 공간을 많이 차지하고 색상 블록이 과하게 강조돼 정돈된 느낌이 부족했습니다. 색상을 과하게 드러내지 않으면서 선택 상태가 한눈에 보이도록 깔끔하게 개선했습니다.

## 🔍 변경 사항

- 색상 카드 그리드 → 원형 색상 스와치 나열 형태로 변경
- 선택된 스와치만 알약(pill) 형태로 확장되며 내부에 색상 점 + 테마명 표시 (별도 텍스트 줄 제거)
- AI 자동 생성 옵션도 동일한 스와치/확장 패턴으로 통일
- 썸네일이 없을 때 AI 옵션 비활성(흐림) 처리 유지
- 미선택 시 기본 테마 안내 문구 표시
- 다양한 테마 색상에서도 라벨 가독성이 유지되도록 확장 영역에 연한 배경(bg-primary/10 / bg-indigo-50) 적용

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #218 

## 📸 스크린샷 (UI 변경 시 필수)


https://github.com/user-attachments/assets/ca8490d3-9472-48c8-873a-5fe6d1b06026




## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
