### PR TITLE
[PR] 3D 전시관 캐릭터 이름표에 칭호 표시

### DIFF
--- a/server/ws.ts
+++ b/server/ws.ts
@@ -22,6 +22,7 @@ type RoomEntry = {
   chat: Chat[] | [];
   userName: string;
   model: CharacterModel;
+  title: string | null;
 };
 
 // roomId → (userId → RoomEntry)
@@ -78,7 +79,8 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
       myUserId = userId;
       const userName = (msg.userName as string) || userId;
       const model = (msg.model as CharacterModel) || 'human';
-      room.set(userId, { ws, state: null, chat: [], userName, model });
+      const title = (msg.title as string) ?? null;
+      room.set(userId, { ws, state: null, chat: [], userName, model, title });
 
       console.log(
         `[ws] join  room=${roomId} userId=${userId} total=${room.size}`
@@ -93,6 +95,7 @@ wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
               userId: id,
               userName: entry.userName,
               model: entry.model,
+              title: entry.title,
             })
           );
           if (entry.state) {

--- a/src/app/(exhibitions)/gallery/[id]/page.tsx
+++ b/src/app/(exhibitions)/gallery/[id]/page.tsx
@@ -30,13 +30,15 @@ export default function GalleryExhibitionPage() {
   } = useGalleryData(id);
 
   const [selectedModel, setSelectedModel] = useState<CharacterModel>('human');
+  const [achievement, setAchievement] = useState<MyAchievements | null>(null);
 
   const { sendMove, sendMessage, remotePlayersRef, playerInfo, chatHistory } =
     usePlayerSocket(
       id,
       user?.id ?? null,
       user?.user_metadata?.username ?? 'guest',
-      selectedModel
+      selectedModel,
+      achievement?.selectedTitle ?? null
     );
 
   const [isSceneReady, setIsSceneReady] = useState(false);
@@ -51,7 +53,6 @@ export default function GalleryExhibitionPage() {
   );
   const [showStampComplete, setShowStampComplete] = useState(false);
   const [showStampBook, setShowStampBook] = useState(false);
-  const [achievement, setAchievement] = useState<MyAchievements | null>(null);
   // 도장 연출: key를 증가시켜 재마운트 → 애니메이션 재생
   const [stampFxId, setStampFxId] = useState(0);
   const stampAudioRef = useRef<HTMLAudioElement | null>(null);
@@ -295,6 +296,7 @@ export default function GalleryExhibitionPage() {
             playerInfo={playerInfo}
             selectedModel={selectedModel}
             myName={myName}
+            myTitle={achievement?.selectedTitle ?? null}
             isThirdPerson={isThirdPerson}
             onToggleThirdPerson={() => setIsThirdPerson((v) => !v)}
           />

--- a/src/components/exhibition-gallery/threejs/LocalPlayerCharacter.tsx
+++ b/src/components/exhibition-gallery/threejs/LocalPlayerCharacter.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { CharacterModel } from '@/hooks/usePlayerSocket';
+import { TITLE_ICONS } from '@/lib/achievements/definitions';
 import HumanCharacter from './characters/HumanCharacter';
 import BunnyCharacter from './characters/BunnyCharacter';
 import CartoonCharacter from './characters/CartoonCharacter';
@@ -13,12 +14,14 @@ export default function LocalPlayerCharacter({
   playerPosRef,
   playerYawRef,
   myName,
+  myTitle,
 }: {
   model: CharacterModel;
   visible: boolean;
   playerPosRef: React.RefObject<THREE.Vector3>;
   playerYawRef: React.RefObject<number>;
   myName?: string;
+  myTitle?: string | null;
 }) {
   const groupRef = useRef<THREE.Group>(null);
 
@@ -35,9 +38,17 @@ export default function LocalPlayerCharacter({
   return (
     <group ref={groupRef} visible={visible}>
       {visible && (
-        <Html position={[0, 1.9, 0]} center>
-          <div className="text-primary w-fit rounded-full bg-black/50 px-3 py-0.5 text-sm font-bold whitespace-nowrap">
-            {myName}
+        <Html position={[0, 1.9, 0]} center zIndexRange={[30, 0]}>
+          <div className="flex flex-col items-center gap-0.5">
+            {myTitle && (
+              <div className="bg-primary/90 flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold whitespace-nowrap text-white">
+                {TITLE_ICONS[myTitle] && <span>{TITLE_ICONS[myTitle]}</span>}
+                {myTitle}
+              </div>
+            )}
+            <div className="text-primary w-fit rounded-full bg-black/50 px-3 py-0.5 text-sm font-bold whitespace-nowrap">
+              {myName}
+            </div>
           </div>
         </Html>
       )}

--- a/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
+++ b/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { PlayerInfo, RemotePlayerData } from '@/hooks/usePlayerSocket';
+import { TITLE_ICONS } from '@/lib/achievements/definitions';
 import { Html } from '@react-three/drei';
 import HumanCharacter from './characters/HumanCharacter';
 import BunnyCharacter from './characters/BunnyCharacter';
@@ -19,6 +20,7 @@ function RemotePlayer({
   const playerId = playerInfo.userId;
   const playerName = playerInfo.userName;
   const playerModel = playerInfo.model;
+  const playerTitle = playerInfo.title;
   const initializedRef = useRef(false);
   const [visible, setVisible] = useState(false);
 
@@ -48,8 +50,18 @@ function RemotePlayer({
     <group ref={groupRef} visible={visible}>
       {visible && (
         <Html position={[0, 1.9, 0]} center zIndexRange={[30, 0]}>
-          <div className="w-fit rounded-full bg-black/50 px-3 py-0.5 text-sm whitespace-nowrap text-white">
-            {playerName}
+          <div className="flex flex-col items-center gap-0.5">
+            {playerTitle && (
+              <div className="bg-primary/90 flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold whitespace-nowrap text-white">
+                {TITLE_ICONS[playerTitle] && (
+                  <span>{TITLE_ICONS[playerTitle]}</span>
+                )}
+                {playerTitle}
+              </div>
+            )}
+            <div className="w-fit rounded-full bg-black/50 px-3 py-0.5 text-sm whitespace-nowrap text-white">
+              {playerName}
+            </div>
           </div>
         </Html>
       )}

--- a/src/components/exhibition-gallery/threejs/Scene.tsx
+++ b/src/components/exhibition-gallery/threejs/Scene.tsx
@@ -49,6 +49,7 @@ export default function Scene2({
   remotePlayersRef,
   playerInfo,
   myName,
+  myTitle,
   selectedModel = 'human',
   isThirdPerson,
   onToggleThirdPerson,
@@ -64,6 +65,7 @@ export default function Scene2({
   remotePlayersRef?: React.RefObject<Map<string, RemotePlayerData>>;
   playerInfo?: PlayerInfo[];
   myName: string;
+  myTitle?: string | null;
   selectedModel?: CharacterModel;
   isThirdPerson?: boolean;
   onToggleThirdPerson?: () => void;
@@ -271,6 +273,7 @@ export default function Scene2({
       />
       <LocalPlayerCharacter
         myName={myName}
+        myTitle={myTitle}
         model={selectedModel}
         visible={isThirdPerson ?? false}
         playerPosRef={playerPosRef}

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -128,19 +128,20 @@ export function usePlayerSocket(
         ]);
       } else if (msg.type === 'join') {
         userNamesRef.current.set(msg.userId, msg.userName);
-        setPlayerInfo((prev) =>
-          prev.find((p) => p.userId === msg.userId)
-            ? prev
-            : [
-                ...prev,
-                {
-                  userId: msg.userId,
-                  userName: msg.userName,
-                  model: msg.model,
-                  title: msg.title ?? null,
-                },
-              ]
-        );
+        setPlayerInfo((prev) => {
+          // 재접속(칭호 갱신 등) 시 기존 항목을 갱신(upsert)해 최신 title 반영
+          const nextEntry = {
+            userId: msg.userId,
+            userName: msg.userName,
+            model: msg.model,
+            title: msg.title ?? null,
+          };
+          const idx = prev.findIndex((p) => p.userId === msg.userId);
+          if (idx === -1) return [...prev, nextEntry];
+          const next = [...prev];
+          next[idx] = { ...next[idx], ...nextEntry };
+          return next;
+        });
       } else if (msg.type === 'leave') {
         remotePlayersRef.current.delete(msg.userId);
         userNamesRef.current.delete(msg.userId);

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -15,6 +15,7 @@ export type PlayerInfo = {
   userId: string;
   userName: string;
   model: CharacterModel;
+  title?: string | null;
 };
 
 export type ChatHistory = { userId: string; userName: string; message: string };
@@ -24,7 +25,13 @@ type ChatRaw = {
   message: string;
 };
 type OutboundMessage =
-  | { type: 'join'; userId: string; userName: string; model: CharacterModel }
+  | {
+      type: 'join';
+      userId: string;
+      userName: string;
+      model: CharacterModel;
+      title?: string | null;
+    }
   | { type: 'leave'; userId: string }
   | {
       type: 'move';
@@ -45,7 +52,13 @@ type InboundMessage =
       z: number;
       yaw: number;
     }
-  | { type: 'join'; userId: string; userName: string; model: CharacterModel }
+  | {
+      type: 'join';
+      userId: string;
+      userName: string;
+      model: CharacterModel;
+      title?: string | null;
+    }
   | { type: 'leave'; userId: string }
   | { type: 'message'; userId: string; message: string }
   | { type: 'messageInit'; userId: string; messages: ChatRaw[] };
@@ -56,7 +69,8 @@ export function usePlayerSocket(
   exhibitionId: string,
   userId: string | null,
   userName: string | null,
-  model: CharacterModel = 'human'
+  model: CharacterModel = 'human',
+  title: string | null = null
 ) {
   const wsRef = useRef<WebSocket | null>(null);
   const lastSentAt = useRef(0);
@@ -90,7 +104,7 @@ export function usePlayerSocket(
       const myName = userName ?? userId;
       userNamesRef.current.set(userId, myName);
       ws.send(
-        JSON.stringify({ type: 'join', userId, userName: myName, model })
+        JSON.stringify({ type: 'join', userId, userName: myName, model, title })
       );
     };
 
@@ -123,6 +137,7 @@ export function usePlayerSocket(
                   userId: msg.userId,
                   userName: msg.userName,
                   model: msg.model,
+                  title: msg.title ?? null,
                 },
               ]
         );
@@ -151,7 +166,7 @@ export function usePlayerSocket(
       }
       ws.close();
     };
-  }, [exhibitionId, userId, userName, model]);
+  }, [exhibitionId, userId, userName, model, title]);
 
   const sendMove = useCallback(
     (camera: THREE.Camera) => {

--- a/src/lib/achievements/definitions.ts
+++ b/src/lib/achievements/definitions.ts
@@ -44,6 +44,11 @@ export const ACHIEVEMENTS: AchievementDef[] = [
   },
 ];
 
+// 칭호명 → 대표 이모지 아이콘 (이름표 등에서 칭호 옆 표시용)
+export const TITLE_ICONS: Record<string, string> = Object.fromEntries(
+  ACHIEVEMENTS.map((a) => [a.title, a.icon])
+);
+
 // 주어진 진행 상황으로 업적 달성 여부 판정
 export function isAchieved(
   condition: AchievementCondition,


### PR DESCRIPTION
## 📌 개요

스탬프 업적으로 획득 및 장착한 칭호가 마이페이지와 스탬프북에서만 보였습니다.
3D 전시관에서 캐릭터 이름표에 장착 칭호를 표시해, 다른 사람과 함께 있을 때 성취가 드러나고 칭호 수집 동기를 높이도록 했습니다.

## 🔍 변경 사항

- usePlayerSocket: `title` 파라미터 + `PlayerInfo.title` + join 메시지(out/in)에 title 추가·저장
- WS 서버(server/ws.ts): `RoomEntry`에 title 저장 + 기존 플레이어 정보를 신규 접속자에게 보낼 때 title 포함 (양방향 칭호 동기화)
- gallery 페이지: 내 칭호(achievement.selectedTitle)를 소켓·Scene2에 전달
- LocalPlayerCharacter / RemotePlayers: 이름표에 칭호 칩 + 대표 이모지 아이콘(TITLE_ICONS) 렌더
- LocalPlayerCharacter `<Html>`에 `zIndexRange` 추가 -> 스탬프북 모달 위로 이름표가 뚫고 보이던 버그 수정

## 🔗 관련 이슈 번호

close #217 

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1495" height="763" alt="스크린샷 2026-06-22 오후 12 36 12" src="https://github.com/user-attachments/assets/09562064-f623-4c85-8305-14b050d897b7" />

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요? (내 칭호·아이콘 표시 확인)
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요? (build 통과)

## 🚩 기타 참고 사항

- 칭호 미장착 사용자는 기존처럼 이름만 표시
