### PR TITLE
[PR] 3인칭일때 영상재생 기준좌표 수정

### DIFF
--- a/src/components/exhibition-create/ThemeSelector.tsx
+++ b/src/components/exhibition-create/ThemeSelector.tsx
@@ -21,52 +21,59 @@ export default function ThemeSelector({
   hasThumb: boolean;
 }) {
   return (
-    <div className="flex flex-col gap-3">
-      <div className="grid grid-cols-5 gap-2">
-        {/* AI 자동 생성 카드 */}
+    <div className="flex flex-col gap-2.5">
+      <div className="flex flex-wrap items-center gap-2.5">
+        {/* AI 자동 생성 스와치 */}
         <button
           type="button"
           onClick={() => onChange(value === 'ai' ? null : 'ai')}
-          className={`flex flex-col overflow-hidden rounded-[10px] border-2 transition-all duration-150 ${
+          aria-label="AI 자동 생성"
+          title="AI 자동 생성"
+          className={`inline-flex h-9 items-center justify-center gap-1.5 rounded-full transition-all duration-200 ${
             !hasThumb
-              ? 'cursor-not-allowed opacity-40'
+              ? 'w-9 cursor-not-allowed bg-linear-to-br from-violet-400 to-indigo-500 opacity-30'
               : value === 'ai'
-                ? 'border-primary shadow-md'
-                : 'border-transparent hover:border-gray-200'
+                ? 'bg-indigo-50 pr-3.5 pl-1.5 text-sm font-semibold text-indigo-600 ring-2 ring-indigo-500'
+                : 'w-9 bg-linear-to-br from-violet-400 to-indigo-500 hover:scale-110'
           }`}
           disabled={!hasThumb}
         >
-          <div className="flex h-11 w-full items-center justify-center bg-gradient-to-br from-violet-400 to-indigo-500">
-            <Wand2 className="h-5 w-5 text-white" />
-          </div>
-          <div className="w-full bg-indigo-50 px-1 py-[5px] text-center text-[10px] leading-tight font-semibold text-indigo-600">
-            AI 자동
-          </div>
+          {value === 'ai' ? (
+            <>
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-linear-to-br from-violet-400 to-indigo-500">
+                <Wand2 className="h-3.5 w-3.5 text-white" />
+              </span>
+              AI 자동
+            </>
+          ) : (
+            <Wand2 className="h-4 w-4 text-white" />
+          )}
         </button>
 
         {ALL_PRESETS.map((preset) => {
           const isSelected = value === preset.id;
+          const label = PRESET_LABELS[preset.id] ?? preset.id;
           return (
             <button
               key={preset.id}
               type="button"
               onClick={() => onChange(isSelected ? null : preset.id)}
-              className={`flex flex-col overflow-hidden rounded-[10px] border-2 transition-all duration-150 ${
+              aria-label={label}
+              title={label}
+              className={`inline-flex h-9 items-center gap-1.5 rounded-full transition-all duration-200 ${
                 isSelected
-                  ? 'border-primary shadow-md'
-                  : 'border-transparent hover:border-gray-200'
+                  ? 'bg-primary/10 text-primary ring-primary pr-3.5 pl-1.5 text-sm font-semibold ring-2'
+                  : 'w-9 ring-1 ring-black/10 hover:scale-110'
               }`}
+              style={isSelected ? undefined : { background: getCardBg(preset) }}
             >
-              <div
-                className="h-11 w-full"
-                style={{ background: getCardBg(preset) }}
-              />
-              <div
-                className="w-full px-1 py-[5px] text-center text-[10px] leading-tight font-semibold text-gray-700"
-                style={{ backgroundColor: preset.floor.color || '#fff' }}
-              >
-                {PRESET_LABELS[preset.id] ?? preset.id}
-              </div>
+              {isSelected && (
+                <span
+                  className="h-6 w-6 rounded-full ring-1 ring-black/10"
+                  style={{ background: getCardBg(preset) }}
+                />
+              )}
+              {isSelected && label}
             </button>
           );
         })}

--- a/src/components/exhibition-gallery/threejs/InnerWall.tsx
+++ b/src/components/exhibition-gallery/threejs/InnerWall.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Group, Texture } from 'three';
+import { Group, Texture, Vector3 } from 'three';
 import Painting from './Painting';
 import { GalleryUIArtworkProps, WAllType } from '@/types/gallery';
 
@@ -10,6 +10,8 @@ export default function InnerWalls({
   paintingRefs,
   htmlRefs,
   wallTexture = null,
+  playerPosRef,
+  isThirdPerson = false,
 }: {
   paintingTextures: Texture[];
   init: GalleryUIArtworkProps[];
@@ -17,6 +19,8 @@ export default function InnerWalls({
   paintingRefs: React.RefObject<(Group | null)[]>;
   htmlRefs: React.RefObject<(HTMLDivElement | null)[]>;
   wallTexture?: Texture | null;
+  playerPosRef?: React.RefObject<Vector3>;
+  isThirdPerson?: boolean;
 }) {
   let interiorBackIdx = walls.length;
   const assignments = walls.map((wall, i) => ({
@@ -56,6 +60,8 @@ export default function InnerWalls({
                   htmlRefs.current[front] = el;
                 }}
                 videoUrl={init[front].video_url}
+                playerPosRef={playerPosRef}
+                isThirdPerson={isThirdPerson}
               />
             )}
 
@@ -73,6 +79,8 @@ export default function InnerWalls({
                     htmlRefs.current[back] = el;
                   }}
                   videoUrl={init[back].video_url}
+                  playerPosRef={playerPosRef}
+                  isThirdPerson={isThirdPerson}
                 />
               </group>
             )}

--- a/src/components/exhibition-gallery/threejs/Painting.tsx
+++ b/src/components/exhibition-gallery/threejs/Painting.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { RefObject, useEffect, useRef } from 'react';
 import {
   CanvasTexture,
   Group,
@@ -52,6 +52,8 @@ export default function Painting({
   paintingRef,
   htmlRef,
   videoUrl,
+  playerPosRef,
+  isThirdPerson = false,
 }: {
   img: Texture;
   details: GalleryUIArtworkProps;
@@ -60,6 +62,8 @@ export default function Painting({
   paintingRef?: (mesh: Group | null) => void;
   htmlRef?: (el: HTMLDivElement | null) => void;
   videoUrl?: string | null;
+  playerPosRef?: RefObject<Vector3>;
+  isThirdPerson?: boolean;
 }) {
   const localRef = useRef<Group>(null);
   const meshRef = useRef<Mesh>(null);
@@ -123,8 +127,10 @@ export default function Painting({
     const videoData = videoDataRef.current;
     if (!localRef.current || !meshRef.current) return;
     localRef.current.getWorldPosition(worldPosRef.current);
-    const near =
-      camera.position.distanceTo(worldPosRef.current) < VIDEO_NEAR_THRESHOLD;
+    // 3인칭은 카메라가 플레이어에서 떨어져 궤도를 돌므로 플레이어 좌표 기준으로 판정
+    const refPos =
+      isThirdPerson && playerPosRef ? playerPosRef.current : camera.position;
+    const near = refPos.distanceTo(worldPosRef.current) < VIDEO_NEAR_THRESHOLD;
 
     if (videoData) {
       const videoReady = videoData.video.readyState >= 3;

--- a/src/components/exhibition-gallery/threejs/Room.tsx
+++ b/src/components/exhibition-gallery/threejs/Room.tsx
@@ -29,6 +29,7 @@ export default function Room({
   wallColor = defaultPreset.wallColor,
   wallPattern,
   playerPosRef,
+  isThirdPerson = false,
 }: {
   init: GalleryUIArtworkProps[];
   size: number;
@@ -43,6 +44,7 @@ export default function Room({
   wallColor?: string;
   wallPattern?: WallPatternConfig;
   playerPosRef: RefObject<THREE.Vector3>;
+  isThirdPerson?: boolean;
 }) {
   const [artworks, setArtworks] = useState(init);
   const loadingRef = useRef(false);
@@ -258,6 +260,8 @@ export default function Room({
         paintingRefs={paintingRefs}
         htmlRefs={htmlRefs}
         wallTexture={wallTexture}
+        playerPosRef={playerPosRef}
+        isThirdPerson={isThirdPerson}
       />
     </>
   );

--- a/src/components/exhibition-gallery/threejs/Scene.tsx
+++ b/src/components/exhibition-gallery/threejs/Scene.tsx
@@ -236,6 +236,7 @@ export default function Scene2({
         wallColor={mergedPreset.wallColor}
         wallPattern={mergedPreset.wallPattern}
         playerPosRef={playerPosRef}
+        isThirdPerson={isThirdPerson ?? false}
       />
       <DynamicDecorations
         preset={mergedPreset}


### PR DESCRIPTION
## 📌 개요

3인칭 시점에서 영상 작품 재생 근접 판정이 camera.position 기준으로 동작해, 카메라가 플레이어로부터 떨어져 궤도를 도는 3인칭 특성상 영상이 의도와 다르게 재생되던 문제를 수정했습니다. (플레이어는 작품 앞에 있어도 카메라가 빠지면 재생 안 됨 / 카메라만 가까우면 플레이어가 멀어도 재생됨)

## 🔍 변경 사항

- Painting.tsx: 영상 근접 판정 기준 좌표를 시점에 따라 분기 — 3인칭은 playerPosRef, 1인칭은 기존 camera.position 사용
- InnerWall.tsx / Room.tsx / Scene.tsx: playerPosRef·isThirdPerson prop을 Painting까지 전달하도록 경로 연결 (Scene → Room → InnerWalls → Painting)

## 🔗 관련 이슈 번호

> 풀리퀘스트와 관련된 이슈를 언급해주세요.

- 예: close #222 

## 📸 스크린샷 (UI 변경 시 필수)

> 변경된 UI 스크린샷을 보여주세요.

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요?
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요?

## 🚩 기타 참고 사항

> 리뷰어가 알아야 할 특이사항이나 향후 과제가 있다면 적어주세요.
