### PR TITLE
[PR] 멀티플레이어 입장 직후 칭호 로드로 인한 위치 동기화 오류

### DIFF
--- a/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
+++ b/src/components/exhibition-gallery/threejs/RemotePlayers.tsx
@@ -11,9 +11,11 @@ import CartoonCharacter from './characters/CartoonCharacter';
 function RemotePlayer({
   playerInfo,
   remotePlayersRef,
+  size,
 }: {
   playerInfo: PlayerInfo;
   remotePlayersRef: React.RefObject<Map<string, RemotePlayerData>>;
+  size?: number;
 }) {
   const groupRef = useRef<THREE.Group>(null);
   const targetPos = useRef(new THREE.Vector3());
@@ -24,19 +26,29 @@ function RemotePlayer({
   const initializedRef = useRef(false);
   const [visible, setVisible] = useState(false);
 
+  // 이상 좌표(동기화 순간 오류 등)가 와도 방 밖으로 튀지 않도록 범위 제한
+  const clampToRoom = (v: number) => {
+    if (size === undefined) return v;
+    const limit = size / 2 - 0.5;
+    return Math.max(-limit, Math.min(limit, v));
+  };
+
   useFrame(() => {
     const data = remotePlayersRef.current.get(playerId);
     if (!data || !groupRef.current) return;
 
+    const cx = clampToRoom(data.x);
+    const cz = clampToRoom(data.z);
+
     if (!initializedRef.current) {
-      groupRef.current.position.set(data.x, 0, data.z);
+      groupRef.current.position.set(cx, 0, cz);
       groupRef.current.rotation.y = data.yaw;
       initializedRef.current = true;
       setVisible(true);
       return;
     }
 
-    targetPos.current.set(data.x, 0, data.z);
+    targetPos.current.set(cx, 0, cz);
     groupRef.current.position.lerp(targetPos.current, 0.15);
 
     let diff = data.yaw - groupRef.current.rotation.y;
@@ -80,9 +92,11 @@ function RemotePlayer({
 export default function RemotePlayers({
   playerInfo,
   remotePlayersRef,
+  size,
 }: {
   playerInfo: PlayerInfo[];
   remotePlayersRef: React.RefObject<Map<string, RemotePlayerData>>;
+  size?: number;
 }) {
   return (
     <>
@@ -91,6 +105,7 @@ export default function RemotePlayers({
           key={info.userId}
           playerInfo={info}
           remotePlayersRef={remotePlayersRef}
+          size={size}
         />
       ))}
     </>

--- a/src/components/exhibition-gallery/threejs/Scene.tsx
+++ b/src/components/exhibition-gallery/threejs/Scene.tsx
@@ -254,6 +254,7 @@ export default function Scene2({
         <RemotePlayers
           playerInfo={playerInfo}
           remotePlayersRef={remotePlayersRef}
+          size={roomSize}
         />
       )}
       <Player

--- a/src/hooks/usePlayerSocket.ts
+++ b/src/hooks/usePlayerSocket.ts
@@ -74,6 +74,10 @@ export function usePlayerSocket(
 ) {
   const wsRef = useRef<WebSocket | null>(null);
   const lastSentAt = useRef(0);
+  // 칭호는 입장 후 비동기로 로드된다. deps에 넣어 소켓을 재접속하면
+  // 입장 직후 leave/rejoin churn으로 위치 동기화가 꼬일 수 있어,
+  // ref로 들고 있다가 기존 연결로 join을 재전송(re-announce)해 갱신한다.
+  const titleRef = useRef(title);
 
   const remotePlayersRef = useRef<Map<string, RemotePlayerData>>(new Map());
   const userNamesRef = useRef<Map<string, string>>(new Map());
@@ -104,7 +108,13 @@ export function usePlayerSocket(
       const myName = userName ?? userId;
       userNamesRef.current.set(userId, myName);
       ws.send(
-        JSON.stringify({ type: 'join', userId, userName: myName, model, title })
+        JSON.stringify({
+          type: 'join',
+          userId,
+          userName: myName,
+          model,
+          title: titleRef.current,
+        })
       );
     };
 
@@ -167,7 +177,24 @@ export function usePlayerSocket(
       }
       ws.close();
     };
-  }, [exhibitionId, userId, userName, model, title]);
+  }, [exhibitionId, userId, userName, model]);
+
+  // 칭호 변경 시: 소켓 재접속 없이 기존 연결로 join 재전송 → 서버가 broadcast,
+  // 다른 클라가 upsert로 최신 칭호 반영
+  useEffect(() => {
+    titleRef.current = title;
+    const ws = wsRef.current;
+    if (!userId || !ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(
+      JSON.stringify({
+        type: 'join',
+        userId,
+        userName: userName ?? userId,
+        model,
+        title,
+      })
+    );
+  }, [title, userId, userName, model]);
 
   const sendMove = useCallback(
     (camera: THREE.Camera) => {


### PR DESCRIPTION
## 📌 개요

3D 전시관에서 다른 플레이어가 입장한 직후 한 명이 전시관 밖으로 텔레포트되는 버그를 수정했습니다. 

## 🔍 변경 사항

- usePlayerSocket: `title`을 effect 의존성에서 제거하고 `titleRef`로 보관 -> 칭호 로드 시 소켓 재접속 제거. 칭호 변경 시에는 기존 연결로 join을 재전송(re-announce)해 서버 broadcast -> 다른 클라가 upsert로 갱신

- RemotePlayers: 원격 플레이어 렌더 좌표를 방 범위로 clamp -> 이상 좌표가 들어와도 전시관 밖으로 튀지 않도록 안전망 추가
- Scene: RemotePlayers에 roomSize 전달

## 🔗 관련 이슈 번호

close #225 

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경 없음

## 🧪 테스트 결과

- [x] 코드가 정상 작동하는 지 확인했나요? (2인 접속, 입장 직후 텔레포트 미발생)
- [x] 브라우저 및 개발 환경 콘솔에 오류가 나오는 지 확인했나요?
- [x] 라우팅이 정상 작동하는 지 확인했나요?
- [x] 빌드 시 오류가 발생하는 지 확인했나요? (build 통과)

## 🚩 기타 참고 사항

- WS 서버는 변경 없고, 기존 raw broadcast가 재전송된 join도 그대로 중계하므로 서버 작업 불필요함.
